### PR TITLE
Fix: Course link navigation blocked by ParticlesComponent

### DIFF
--- a/src/components/particle.tsx
+++ b/src/components/particle.tsx
@@ -1,9 +1,11 @@
+import * as React from "react";
 import Particles, { initParticlesEngine } from "@tsparticles/react";
 import { useEffect, useMemo, useState } from "react";
 import { loadSlim } from "@tsparticles/slim";
 
 const ParticlesComponent = (props) => {
   const [init, setInit] = useState(false);
+
   useEffect(() => {
     initParticlesEngine(async (engine) => {
       await loadSlim(engine);
@@ -18,6 +20,9 @@ const ParticlesComponent = (props) => {
 
   const options = useMemo(
     () => ({
+      fullScreen: {
+        enable: false, // Important: disable built-in fullscreen
+      },
       fpsLimit: 120,
       interactivity: {
         events: {
@@ -81,7 +86,6 @@ const ParticlesComponent = (props) => {
         opacity: {
           value: 0.7,
         },
-
         size: {
           value: { min: 1, max: 3 },
         },
@@ -91,7 +95,21 @@ const ParticlesComponent = (props) => {
     []
   );
 
-  return <Particles id={props.id} options={options} />;
+  return (
+    <div
+      style={{
+        position: "fixed",
+        width: "100vw",
+        height: "100vh",
+        top: 0,
+        left: 0,
+        zIndex: -1, // Critical: ensures it's in the background
+        pointerEvents: "none", // Ensures it doesn't block clicks
+      }}
+    >
+      <Particles id={props.id} options={options} />
+    </div>
+  );
 };
 
 export default ParticlesComponent;


### PR DESCRIPTION
This PR resolves an issue where the ParticlesComponent was intercepting user interactions,
preventing course links and route navigation from working correctly.

✅ Changes:
- Wrapped Particles in a fixed-position div
- Added `pointerEvents: none` and `zIndex: -1` to prevent interaction blocking
- Disabled built-in fullscreen mode from tsParticles

This ensures smooth navigation and interaction across routes.
