### PR TITLE
Replace "Account Support" with "Terms of Service" in Footer

### DIFF
--- a/src/theme/Footer/index.tsx
+++ b/src/theme/Footer/index.tsx
@@ -226,17 +226,18 @@ const Footer: React.FC = () => {
                     to="#"
                     className="mb-3 inline-block text-base text-gray-300 hover:text-[--ifm-color-primary]"
                   >
-                    Account Support
+                    {/* Account Support */}
+                    Terms of Service
                   </Link>
                 </li>
-                <li>
+                {/* <li>
                   <Link
                     to="#"
                     className="mb-3 inline-block text-base text-gray-300 hover:text-[--ifm-color-primary]"
                   >
                     Accessibility Support
                   </Link>
-                </li>
+                </li> */}
               </ul>
             </div>
           </div>


### PR DESCRIPTION


Fixes #120 

## Changes Made

- Replaced the "Account Support" footer link with "Terms of Service" for better relevance and professionalism.
- Commented out the "Accessibility Support" link as the site does not currently offer specific accessibility features.

## Checklist
 This is already assigned Issue to me, not an unassigned issue.
