### PR TITLE
Integrate Pinterest Tag

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -27,14 +27,10 @@ const config: Config = {
       async: true,
     },
     {
-      content: `
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', 'G-W02Z2VJYCR', {
-          debug_mode: ${process.env.NODE_ENV !== 'production' ? 'true' : 'false'}
-        });
-      `,
+      src: '/gtag-init.js',
+    },
+    {
+      src: '/pinterest-init.js',
     },
   ],
 
@@ -289,7 +285,7 @@ const config: Config = {
       },
     ],
   ],
-  scripts: [],
+  //  scripts: [],
 };
 
 export default config;

--- a/static/gtag-init.js
+++ b/static/gtag-init.js
@@ -1,0 +1,8 @@
+console.log('✅ gtag-init.js loaded');
+
+window.dataLayer = window.dataLayer || [];
+function gtag() { dataLayer.push(arguments); }
+gtag('js', new Date());
+gtag('config', 'G-W02ZZ2VJYCR', {
+  debug_mode: location.hostname === 'localhost' ? 'true' : 'false'
+});

--- a/static/pinterest-init.js
+++ b/static/pinterest-init.js
@@ -1,0 +1,20 @@
+console.log('✅ pinterest-init.js loaded');
+!function(e){
+  if (!window.pintrk) {
+    window.pintrk = function () {
+      window.pintrk.queue.push(Array.prototype.slice.call(arguments));
+    };
+    var n = window.pintrk;
+    n.queue = [], n.version = "3.0";
+    var t = document.createElement("script");
+    t.async = !0;
+    t.src = e;
+    var r = document.getElementsByTagName("script")[0];
+    r.parentNode.insertBefore(t, r);
+  }
+}("https://s.pinimg.com/ct/core.js");
+
+pintrk('load', '2613717138491', {
+  em: 'b58906c504c5638798eb06151e6f49af1b0e4c6c3b5d4f30d9c2268dbe6f9d60' // example hashed email
+});
+pintrk('page');


### PR DESCRIPTION
## Description

This PR integrates Pinterest Tag tracking into the Docusaurus project in a modular and maintainable way.

Fixes #152 

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made

- static/pinterest-init.js
This script initializes Pinterest tracking, loads the core.js script, and sets up the tag with a sample hashed email.
-static/gtag-init.js File
Added gtag-init.js under the static/ directory to improve script separation and allow better control of Google Analytics initialization.

##Notes
This implementation uses a sample em (hashed email); it can be made dynamic in future improvements.
Script is loaded safely on all pages without causing build errors.
No changes made to UI or core logic.


## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have tested my changes across major browsers/devices
- [ ] My changes do not generate new console warnings or errors , I ran `npm run build` 
- [ ] This is already assigned Issue to me, not an unassigned issue.
