### PR TITLE
gssoc/fixed mis-alignment of icons on sidebar closing

### DIFF
--- a/src/pages/dashboard/dashboard.css
+++ b/src/pages/dashboard/dashboard.css
@@ -8,7 +8,7 @@
 
 /* Sidebar Styles */
 .dashboard-sidebar {
-  width: 200px;
+  width: 210px;
   background: var(--ifm-card-background-color);
   border-right: 1px solid var(--ifm-toc-border-color);
   padding: 1.5rem 0;
@@ -100,6 +100,7 @@
   margin-left: 1rem;
   flex-shrink: 0;
   transition: background-color 0.2s ease;
+  margin-bottom: 20px;
 }
 
 .sidebar-toggle:hover {
@@ -132,8 +133,8 @@
 
 .dashboard-sidebar.collapsed .sidebar-toggle {
   position: absolute;
-  right: 5px;
-  top: 10px;
+  margin-right: 20px;
+  top: -1px;
 }
 
 .dashboard-sidebar.collapsed .sidebar-toggle.bottom-toggle {
@@ -143,7 +144,6 @@
 
 .dashboard-sidebar.collapsed .nav-item {
   padding: 0.75rem 1rem;
-  justify-content: center;
 }
 
 .dashboard-sidebar.collapsed .nav-icon {


### PR DESCRIPTION
## Description

- modified dashboard.css
-  now the icons are aligned in collapsed state of sidebar.

https://github.com/user-attachments/assets/c00da64d-bb1f-4c51-a108-2a729b80d350


Fixes #263  (issue)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers/devices
- [x] My changes do not generate new console warnings or errors , I ran `npm run build` and attached scrrenshot in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.
