### PR TITLE
Update community.css for the visibility of about us section in dark mode

### DIFF
--- a/src/pages/community/community.css
+++ b/src/pages/community/community.css
@@ -793,3 +793,42 @@
     padding: 0 20px 24px;
   }
 }
+
+/* Accessibility Enhancements */
+/* Light mode defaults */
+.community-hero-title,
+.community-hero-description,
+.contribution-title,
+.contribution-description,
+.section-title,
+.section-description,
+.section-items li,
+.thank-you-main,
+.thank-you-description,
+.support-text {
+  color: #111827; /* default dark text for light background */
+}
+
+/* Dark mode overrides */
+@media (prefers-color-scheme: dark) {
+  .community-hero-title,
+  .contribution-title,
+  .section-title,
+  .thank-you-main {
+    color: #ffffff; /* white text in dark mode */
+  }
+
+  .community-hero-description,
+  .contribution-description,
+  .section-description,
+  .section-items li,
+  .thank-you-description,
+  .support-text {
+    color: #d1d5db; /* light gray text in dark mode */
+  }
+
+  body,
+  .community-page {
+    background-color: #111827; /* Optional: ensure background is also dark */
+  }
+}


### PR DESCRIPTION
## Fix: "About Us" / Community Page Text Not Visible in Dark Mode
Issue Reference: [#245](https://github.com/recodehive/recode-website/issues/245)

## Description
This PR addresses a UI bug where the text in the Community page (acting as the "About Us" section) was not clearly visible in dark mode. The issue was caused by text colors not adapting to the prefers-color-scheme: dark setting.

## Changes Made
Added dark mode CSS overrides in community.css using @media (prefers-color-scheme: dark).

Applied adaptive text colors to:

Page titles and descriptions

Contribution section headers

List items and thank-you messages

Support section content

Included a fallback dark background color for better readability.

## Result
The page now displays all text elements with appropriate contrast in both light and dark modes.

Improves accessibility and user experience for users with dark theme preferences.