### PR TITLE
Fixed Community Page Layout

### DIFF
--- a/src/pages/community/community.css
+++ b/src/pages/community/community.css
@@ -216,7 +216,7 @@
 
 .contribution-sections {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(2,1fr);
   gap: 24px;
 }
 
@@ -771,6 +771,7 @@
 
   .contribution-sections {
     gap: 32px;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   }
 
   .contribution-section {

--- a/src/pages/community/community.css
+++ b/src/pages/community/community.css
@@ -216,9 +216,8 @@
 
 .contribution-sections {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  grid-template-columns: repeat(2, 1fr);
   gap: 24px;
-  /* tighter gap between cards */
 }
 
 


### PR DESCRIPTION
## Description

# Fix: Contribution Section Layout Consistency

## Description
This PR resolves an issue where the **Contribution Section** layout differed between the local development environment and the deployed environment.

- **Local (expected):** Two cards per row, responsive to screen size.  
- **Production (bug):** Three cards per row were displayed, likely due to container width or rendering differences.  

## Changes Made
- Enforced a maximum of **two cards per row** on larger screens.  
- Ensured responsiveness so cards adjust properly across different screen sizes.  

## Screenshots
**Before (Production Bug):**  
<img width="1892" height="842" alt="image" src="https://github.com/user-attachments/assets/e6755859-8e69-4e49-859e-a9f506c1f05b" />


**After (Fixed):**  
<img width="1791" height="816" alt="image" src="https://github.com/user-attachments/assets/e32ff7e1-ead1-4de9-aaef-1a76a1ba82dd" />


## Expected Behavior
- The contribution section now consistently displays **two cards per row**, matching local development behavior.  
- Layout is responsive and adapts cleanly across screen sizes.

Fixes #427 

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):


## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers/devices
- [x] My changes do not generate new console warnings or errors , I ran `npm run build` and attached scrrenshot in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.
