### PR TITLE
Spaced Out search and mode icon

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1340,3 +1340,23 @@ a {
 .page-enter {
   animation: pageSlideIn 0.6s ease-out;
 }
+
+
+@media screen and (max-width: 768px) {
+  .navbar .navbar__items--right {
+    display: flex;
+    align-items: center;
+    gap: 20px; 
+  }
+
+  .navbar .DocSearch-Button {
+    min-width: 36px;
+    margin-right: 30px;
+  }
+
+  .navbar .colorModeToggle {
+    margin-left: 4px;
+    flex-shrink: 0;
+  }
+}
+


### PR DESCRIPTION
# Fix: Navbar icon overlap in mobile view

## Description
This PR resolves an issue where the **search icon** and the **mode toggle button** (light/dark switch) overlapped in the navbar on smaller screens.  
The overlap made it difficult for users to interact with either element, affecting the overall usability of the navigation bar.

## Changes Made
- Adjusted spacing between the search icon and mode toggle button.  
- Updated mobile view styling to ensure proper alignment without overlap.  
- Ensured responsiveness across different screen sizes so that the layout remains consistent.  

## Expected Behavior
- Both the search icon and the mode toggle button are clearly visible and spaced apart.  
- On smaller screens, the elements align properly without overlapping.  
- The navigation bar maintains a clean and responsive layout across devices.  

## Screenshots
Before
<img width="459" height="801" alt="image" src="https://github.com/user-attachments/assets/da35e0de-7af6-47c2-af07-4c61bcbb0b3e" />
---
After
<img width="349" height="362" alt="image" src="https://github.com/user-attachments/assets/cf42450e-6410-4f44-a55c-a662b61dba1d" />



Fixes #434 

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):


## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers/devices
- [x] My changes do not generate new console warnings or errors , I ran `npm run build` and attached scrrenshot in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.
