### PR TITLE
roling effect  on footer stats

### DIFF
--- a/src/theme/Footer/Layout/index.tsx
+++ b/src/theme/Footer/Layout/index.tsx
@@ -2,6 +2,7 @@
 import React, {type ReactNode, useState, useEffect} from 'react';
 import Link from "@docusaurus/Link";
 import type {Props} from '@theme/Footer/Layout';
+import SlotCounter from "react-slot-counter";
 import './enhanced-footer.css';
 
 // Dynamic stats interface
@@ -11,6 +12,15 @@ interface FooterStats {
   successRate: string;
   supportHours: string;
 }
+
+// Helper function to parse stat values for SlotCounter
+const parseStatValue = (statValue: string) => {
+  // Extract numeric part and suffix from strings like "52K+", "215+", "95%", "24/7"
+  const numericMatch = statValue.match(/^(\d+)/);
+  const numericValue = numericMatch ? parseInt(numericMatch[1]) : 0;
+  const suffix = statValue.replace(/^\d+/, '');
+  return { numericValue, suffix };
+};
 
 export default function FooterLayout({
   style,
@@ -105,7 +115,16 @@ export default function FooterLayout({
                 </svg>
               </div>
               <div className="stat-content">
-                <div className="stat-number">{stats.activeUsers}</div>
+                <div className="stat-number">
+                  <SlotCounter
+                    value={parseStatValue(stats.activeUsers).numericValue}
+                    animateOnVisible={true}
+                    duration={1200}
+                    delay={100}
+                    sequentialAnimationMode={true}
+                  />
+                  {parseStatValue(stats.activeUsers).suffix}
+                </div>
                 <div className="stat-label">Active Learners</div>
               </div>
             </div>
@@ -117,7 +136,16 @@ export default function FooterLayout({
                 </svg>
               </div>
               <div className="stat-content">
-                <div className="stat-number">{stats.tutorials}</div>
+                <div className="stat-number">
+                  <SlotCounter
+                    value={parseStatValue(stats.tutorials).numericValue}
+                    animateOnVisible={true}
+                    duration={1200}
+                    delay={200}
+                    sequentialAnimationMode={true}
+                  />
+                  {parseStatValue(stats.tutorials).suffix}
+                </div>
                 <div className="stat-label">Tutorials</div>
               </div>
             </div>
@@ -129,7 +157,16 @@ export default function FooterLayout({
                 </svg>
               </div>
               <div className="stat-content">
-                <div className="stat-number">{stats.successRate}</div>
+                <div className="stat-number">
+                  <SlotCounter
+                    value={parseStatValue(stats.successRate).numericValue}
+                    animateOnVisible={true}
+                    duration={1200}
+                    delay={300}
+                    sequentialAnimationMode={true}
+                  />
+                  {parseStatValue(stats.successRate).suffix}
+                </div>
                 <div className="stat-label">Success Rate</div>
               </div>
             </div>
@@ -141,7 +178,38 @@ export default function FooterLayout({
                 </svg>
               </div>
               <div className="stat-content">
-                <div className="stat-number">{stats.supportHours}</div>
+                <div className="stat-number">
+                  {stats.supportHours === '24/7' ? (
+                    <>
+                      <SlotCounter
+                        value={24}
+                        animateOnVisible={true}
+                        duration={1200}
+                        delay={400}
+                        sequentialAnimationMode={true}
+                      />
+                      /
+                      <SlotCounter
+                        value={7}
+                        animateOnVisible={true}
+                        duration={1200}
+                        delay={500}
+                        sequentialAnimationMode={true}
+                      />
+                    </>
+                  ) : (
+                    <>
+                      <SlotCounter
+                        value={parseStatValue(stats.supportHours).numericValue}
+                        animateOnVisible={true}
+                        duration={1200}
+                        delay={400}
+                        sequentialAnimationMode={true}
+                      />
+                      {parseStatValue(stats.supportHours).suffix}
+                    </>
+                  )}
+                </div>
                 <div className="stat-label">Support</div>
               </div>
             </div>


### PR DESCRIPTION
## Description
Previously the edit page button is redirecting to the default docusuarus  repo and not on the related file on the githib.
Now , when you click on edit page it will redirect you to the respective file on the project repo accurately

Fixes #433 

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made

Updated the complete docusaurus configuration file so that , it can handle the redirection link to the corresponding file 

## Dependencies

- List any new dependencies or tools required for this change.
- Mention any version updates or configurations that need to be considered.

## Checklist

- [X] My code follows the style guidelines of this project.
- [X] I have tested my changes across major browsers/devices
- [X] My changes do not generate new console warnings or errors , I ran `npm run build` and attached scrrenshot in this PR.
- [X] This is already assigned Issue to me, not an unassigned issue.
### Screenshots
Before the changes :
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ac409837-d47b-40c0-8aac-ca764f16d7aa" />
After : 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/25f5dfd2-f90a-4861-b96c-8729dd726ac0" />



