### PR TITLE
fix: enable dark mode support on Courses page

### DIFF
--- a/src/pages/courses/courses.css
+++ b/src/pages/courses/courses.css
@@ -50,17 +50,25 @@
 
 /* Dark Theme Colors */
 [data-theme='dark'] {
-  --courses-bg-primary: var(--dark-bg-primary);
-  --courses-bg-secondary: var(--dark-bg-secondary);
-  --courses-bg-tertiary: var(--dark-bg-tertiary);
-  --courses-text-primary: var(--dark-text-primary);
-  --courses-text-secondary: var(--dark-text-secondary);
-  --courses-text-muted: var(--dark-text-muted);
-  --courses-border: var(--dark-border);
-  --courses-shadow: var(--dark-shadow);
-  --courses-shadow-lg: var(--dark-shadow-lg);
-  --courses-shadow-xl: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+  /* backgrounds */
+  --courses-bg-primary: #0b1220;   /* page & cards base */
+  --courses-bg-secondary: #0f172a; /* alt sections */
+  --courses-bg-tertiary: #111827;  /* subtle panels */
+
+  /* text */
+  --courses-text-primary: #e5e7eb;   /* main text */
+  --courses-text-secondary: #cbd5e1; /* secondary text */
+  --courses-text-muted: #94a3b8;     /* muted/help text */
+
+  /* borders & effects */
+  --courses-border: #1f2937;
+
+  /* shadows tuned for dark UI */
+  --courses-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.6), 0 1px 2px 0 rgba(0, 0, 0, 0.4);
+  --courses-shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.55), 0 4px 6px -2px rgba(0, 0, 0, 0.5);
+  --courses-shadow-xl: 0 25px 50px -12px rgba(0, 0, 0, 0.7);
 }
+
 
 /* Main page container */
 .courses-page {


### PR DESCRIPTION
## Description

This PR fixes the issue where **the Courses page did not properly respond to the dark mode toggle** in the navbar.  
By defining the correct CSS variables for `[data-theme='dark']`, the page now automatically adapts when the theme is switched.

Fixes #581 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Updated `courses.css` dark theme block to include proper values for:
  - Background colors (`--courses-bg-primary`, `--courses-bg-secondary`, `--courses-bg-tertiary`)
  - Text colors (`--courses-text-primary`, `--courses-text-secondary`, `--courses-text-muted`)
  - Borders & shadows (`--courses-border`, `--courses-shadow`, etc.)
- Removed references to undefined `--dark-*` variables.
- Verified that existing `var(--courses-*)` references in components now switch styles correctly with the navbar toggle.

## Dependencies

- No new dependencies added.
- No config changes required.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers and devices.
- [x] My changes do not generate new console warnings or errors.
- [x] I ran `npm run build` successfully and verified the Courses page works in both dark and light mode.
- [x] This issue was assigned to me before raising the PR.


### before : 

https://github.com/user-attachments/assets/579c81a6-7078-49da-bfe7-64d6b57a011e

### after : 

https://github.com/user-attachments/assets/514c00a7-74a6-4e19-baea-b71399c4412d

