### PR TITLE
Fixed Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ flowchart LR
 
 1. **Clone the repository:** 
    ```bash
-   git clone https://github.com/your-username/recodehive-website.git
+   git clone https://github.com/your-username/recode-website.git
    ```
 
 2. **Navigate to the project directory:**
    ```bash
-   cd recodehive-website
+   cd recode-website
    ```
 
 3. **Prerequesites**
@@ -112,7 +112,7 @@ recode-website/
 |    ├── Google-Student-Ambassador/
 |    ├── ...
 ├── src/                                  🔹Source Code  
-|    └── compenents/
+|    └── components/
 |    ├── css/
 |        └── custom.css
 |    ├── data/


### PR DESCRIPTION
## Description

Fixed a typo in the README file where the command showed `cd recodehive-website` instead of the correct repo name `cd recode-website`.

Fixes #663 

## Type of Change
* [x] Documentation update (README, contribution guidelines, etc.)

## Changes Made
* Updated repo navigation command from `cd recodehive-website` → `cd recode-website`.
* Corrected spelling mistake in project structure (`compenents` → `components`).

## Dependencies

* No new dependencies added.

## Checklist

* [x] My code follows the style guidelines of this project.
* [x] My changes do not generate new console warnings or errors.
* [x] This is already assigned Issue to me, not an unassigned issue.
