### PR TITLE
Fix: Home icon alignment with text in Docs Breadcrumbs

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1449,3 +1449,8 @@ a {
   }
 }
 
+/* ================= MISCELLANEOUS ================= */
+/* Fix Home icon alignment with text in breadcrumbs [Docs] */
+.theme-doc-breadcrumbs a.breadcrumbs__link > svg.breadcrumbHomeIcon_YNFT {
+  display: inline-block;
+}


### PR DESCRIPTION
## Description
Fixed Home icon alignment with text in Docs Breadcrumbs

Fixes #691 

Before fix:
---
<img width="1180" height="183" alt="recode-issue" src="https://github.com/user-attachments/assets/1510e437-3906-41fd-84ab-c960957b3506" />


After fix:
---
<img width="923" height="181" alt="recode-issue-fixed" src="https://github.com/user-attachments/assets/7744d70e-ef1d-42ed-b59d-0edd05028a9d" />


## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made

Updated style for Home icon svg

```
/* Fix Home icon alignment with text in breadcrumbs [Docs] */
.theme-doc-breadcrumbs a.breadcrumbs__link > svg.breadcrumbHomeIcon_YNFT {
  display: inline-block;
}
```

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers and devices
- [x] My changes do not generate new console warnings or errors .
- [x] I ran `npm run build` and attached screenshot(s) in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.
