### PR TITLE
chore: bind Docusaurus dev server to 0.0.0.0 for cross-platform Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,14 @@
 version: "3.9"
 services:
   recodehive:
-    build: 
+    build:
       context: .
     ports:
       - "3000:3000"
     volumes:
       - .:/app
-      - /app/node_modules   # Prevents node_modules being overwritten by the mount
+      - /app/node_modules # Prevents node_modules being overwritten by the mount
     working_dir: /app
-    command: npm run dev   # THIS is the crucial change for hot-reload!
+    command: npm run dev -- --host 0.0.0.0 # THIS is the crucial change for hot-reload!
     environment:
       - NODE_ENV=development


### PR DESCRIPTION
## Description
This PR updates `docker-compose.yml` so that the Docusaurus development server binds to `0.0.0.0`, ensuring it is accessible on Linux, Windows, and macOS hosts.

Fixes #721 

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made

- Updated the command in docker-compose.yml to:
  ```yaml
  command: npm run dev -- --host 0.0.0.0
  ```
- Allows the Docusaurus dev server to bind to all interfaces.

## Dependencies

- No new dependencies

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers and devices
- [ ] My changes do not generate new console warnings or errors .
- [ ] I ran `npm run build` and attached screenshot(s) in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.
