### PR TITLE
chore: remove obsolete version field from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   recodehive:
     build: 


### PR DESCRIPTION
## Description

This PR removes the obsolete `version` attribute from `docker-compose.yml`.
Since newer versions of Docker Compose no longer require or use the version key, this update prevents confusion and avoids warning messages during `docker compose up`.

Fixes #716 

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [x] Other (please specify): Chore / Maintenance

## Changes Made

- Removed the `version: "3.9"` declaration from `docker-compose.yml`.

- Ensures compatibility with current and future versions of Docker Compose.

## Dependencies
- No new dependencies

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested `docker compose up` locally to confirm no issues.
- [ ] I have tested my changes across major browsers and devices
- [ ] My changes do not generate new console warnings or errors .
- [x] This is already assigned Issue to me, not an unassigned issue.
- [ ] I ran `npm run build` and attached screenshot(s) in this PR.
