### PR TITLE
fix: remove rounded corners background projects section

### DIFF
--- a/src/components/ourProjects.tsx
+++ b/src/components/ourProjects.tsx
@@ -164,7 +164,7 @@ const SelectComponent = ({
 
   <div className={`col-span-1 md:col-span-8 p-4 md:p-8 relative overflow-hidden min-h-[80vh] md:min-h-[70vh] ourprojects-embed-container`}>
         {/* Animated Mesh Background */}
-        <div className="absolute inset-0 bg-gradient-to-br from-purple-600/30 via-blue-600/30 via-cyan-500/30 to-emerald-500/30 rounded-3xl">
+        <div className="absolute inset-0 bg-gradient-to-br from-purple-600/30 via-blue-600/30 via-cyan-500/30 to-emerald-500/30">
           <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_50%,rgba(120,119,198,0.3),transparent_50%)] animate-pulse"></div>
           <div className="absolute inset-0 bg-[conic-gradient(from_0deg_at_50%_50%,transparent_0deg,rgba(147,51,234,0.1)_60deg,transparent_120deg)] animate-spin" style={{animationDuration: '20s'}}></div>
         </div>


### PR DESCRIPTION
## Description

Fixed white corner artifacts appearing in the projects section animated background. The rounded corners on the inner gradient container created visual gaps where the parent's background showed through, particularly noticeable on larger screens.

Fixes #723 

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made

- Removed `rounded-3xl` class from the animated mesh background div in the projects section
- Ensures seamless background coverage without white corner gaps
- The inner absolute-positioned background with border-radius was leaving small gaps at corners where parent background showed through
- Trade-off: Flat edges provide consistent visual appearance across all screen sizes without distracting artifacts

**Before**: Rounded corners with white corner artifacts visible at edges  
**After**: Flat edges with complete background coverage

## Dependencies

- No new dependencies added
- No version updates required

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers and devices
- [x] My changes do not generate new console warnings or errors .
- [ ] I ran `npm run build` and attached screenshot(s) in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.

## Screenshots
## Before 
<img width="862" height="339" alt="screenshot-2025-10-03_16-48-34" src="https://github.com/user-attachments/assets/cdffe651-d084-4787-af21-427af2e2631b" />

<img width="1788" height="747" alt="screenshot-2025-10-03_16-44-35" src="https://github.com/user-attachments/assets/6f5a08b1-3ee8-42d2-8616-247426f39906" />

## After
<img width="1825" height="769" alt="screenshot-2025-10-04_11-35-09" src="https://github.com/user-attachments/assets/11ca5a95-c99f-4cf1-b99e-aaeedd733710" />
<img width="846" height="792" alt="screenshot-2025-10-04_11-41-14" src="https://github.com/user-attachments/assets/855e7f27-094e-42b4-bb30-25d2fe36f197" />
