### PR TITLE
docs: remove redundant 'npm i' from setup instructions

### DIFF
--- a/community/contributing-guidelines.md
+++ b/community/contributing-guidelines.md
@@ -41,9 +41,6 @@ flowchart LR
 
     Once you have installed the dependencies, you can run the application locally using:
     ```bash
-    npm i
-    ```
-    ```bash
     npm start
     ```
 


### PR DESCRIPTION
## Description

This PR removes the unnecessary `npm i` command from the setup instructions in the documentation. The step is redundant in the current context and could confuse new contributors or slightly slow down the setup process.

Fixes #770 

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [x] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made

- Removed `npm i` from `contributing-guidelines.md`

- Ensures setup instructions are concise and clear.

## Dependencies

- N/A
- N/A

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers and devices
- [x] My changes do not generate new console warnings or errors .
- [ ] I ran `npm run build` and attached screenshot(s) in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.
