### PR TITLE
Improve search icon visibility in dark mode

### DIFF
--- a/src/pages/blogs/blogs-new.css
+++ b/src/pages/blogs/blogs-new.css
@@ -684,12 +684,13 @@
   transform: none;   
   width: 24px;
   height: 24px;
-  color: #6366f1;
+  color: #757575;
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   pointer-events: none;
+  stroke: #757575;
 }
 
 @keyframes iconPulse {
@@ -703,8 +704,13 @@
   }
 }
 
+[data-theme='dark'] .search-icon {
+  color:#757575;
+  stroke: white;
+}
+
 .search-wrapper:focus-within .search-icon {
-  color: #4f46e5;
+  color:#757575;
   animation-play-state: paused;
   transform: translateY(-50%) scale(1.1);
 }

--- a/src/pages/blogs/index.tsx
+++ b/src/pages/blogs/index.tsx
@@ -103,7 +103,7 @@ export default function Blogs(): React.JSX.Element {
                   </svg>
                   <input
                     type="text"
-                    placeholder="Search articles by title, description, or topic..."
+                    placeholder="Search article by title, topic"
                     className="search-input"
                     value={searchTerm}
                     onChange={handleSearchChange}


### PR DESCRIPTION
## Description
Currently the search icon is barely visible in dark mode on blogs page. 
Now this change will improve visibilty in the dark mode and it also updates the placeholder value of search box.

<!-- 
Provide a brief summary of the changes made to the website and the motivation behind them. Include any relevant issues or tickets.
This helps fast tracking your PR and merge it, Check the respective box below.
-->
Fixes #783 

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made
These changes will improve visibilty in the dark mode and it also updates the placeholder value of search box.
It also adds dark mode to search icon in css. there are total **2 changes** in it.

<!--
Describe the key changes (e.g., new sections, updated components, responsive fixes).
-->

## Dependencies

- List any new dependencies or tools required for this change.
- Mention any version updates or configurations that need to be considered.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers and devices
- [x] My changes do not generate new console warnings or errors .
- [x] I ran `npm run build` and attached screenshot(s) in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.

## Change-1

## Before
<img width="406" height="159" alt="Screenshot 2025-10-05 at 10 07 27 AM" src="https://github.com/user-attachments/assets/ad6d346f-8f97-4e87-973e-a0c31c7e238b" />


## After
<img width="389" height="177" alt="Screenshot 2025-10-05 at 10 05 27 AM" src="https://github.com/user-attachments/assets/958b6276-8577-45cd-9fc8-184675d4bb6f" />

## Change-2

## Before

<img width="276" height="98" alt="Screenshot 2025-10-05 at 10 10 46 AM" src="https://github.com/user-attachments/assets/4638cec2-64f2-4689-8a9e-f8a6e30838a9" />

## After

<img width="267" height="95" alt="Screenshot 2025-10-05 at 10 11 34 AM" src="https://github.com/user-attachments/assets/4907ce04-19be-4f6f-886e-982dacbfd273" />