### PR TITLE
Embed Kingsumo script on giveaway page (#758)

### DIFF
--- a/src/pages/dashboard/giveaway/index.tsx
+++ b/src/pages/dashboard/giveaway/index.tsx
@@ -477,6 +477,23 @@ const GiveawayPage: React.FC = () => {
     setActiveTab("giveaway");
   }, []);
 
+  // Dynamically load Kingsumo embed script for giveaway page
+useEffect(() => {
+  // Create a new script element
+  const script = document.createElement("script");
+  script.src = "https://kingsumo.com/js/embed.js"; // Script URL provided by Kingsumo
+  script.async = true; // Load asynchronously to avoid blocking page render
+
+  // Append the script to the document body
+  document.body.appendChild(script);
+
+  // Cleanup: remove the script when component unmounts to prevent duplicates
+  return () => {
+    document.body.removeChild(script);
+  };
+}, []); // Empty dependency array ensures this runs only once when component mounts
+
+
   useEffect(() => {
     // Simulate fetching leaderboard data
     const fetchLeaderboard = async () => {
@@ -790,6 +807,7 @@ const GiveawayPage: React.FC = () => {
                 <p>Fetching leaderboard data...</p>
               </div>
             ) : (
+              <>
               <div className="giveaway-leaderboard-grid">
                 {leaderboard.map((entry, index) => (
                   <motion.div
@@ -842,6 +860,8 @@ const GiveawayPage: React.FC = () => {
                   </motion.div>
                 ))}
               </div>
+              <div id="kingsumo-embed"></div>
+              </>
             )}
           </motion.section>
         </div>


### PR DESCRIPTION
## Description
Added Kingsumo embed script to the Giveaway page to display the giveaway widget.

<!-- 
Provide a brief summary of the changes made to the website and the motivation behind them. Include any relevant issues or tickets.
This helps fast tracking your PR and merge it, Check the respective box below.
-->
Fixes #758

## Type of Change

- [x] New feature (e.g., new page, component, or functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made

- Added ```useEffect``` in ```GiveawayPage``` to dynamically load the Kingsumo embed script.

- Added ```<div id="kingsumo-embed">``` below the leaderboard grid as the widget placeholder.

- Locally, the script shows a 404 page because the Kingsumo campaign is not public; placement is correct for production.

<!--
Describe the key changes (e.g., new sections, updated components, responsive fixes).
-->

## Dependencies

- List any new dependencies or tools required for this change.
- Mention any version updates or configurations that need to be considered.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers and devices
- [x] My changes do not generate new console warnings or errors .
- [x] I ran `npm run build` and attached screenshot(s) in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.

<img width="1484" height="649" alt="image" src="https://github.com/user-attachments/assets/6c8aa97c-b889-4ee3-99eb-0c3622947e8d" />
