### PR TITLE
fix(Comment Section): Sync theme with site color mode

### DIFF
--- a/src/components/blogCarousel/blogCard.tsx
+++ b/src/components/blogCarousel/blogCard.tsx
@@ -37,8 +37,8 @@ const BlogCard = ({
       initial={{ opacity: 0, y: 40, scale: 0.95 }}
       animate={{ opacity: 1, y: 0, scale: 1 }}
       transition={{ duration: 0.6, ease: "easeOut" }}
-      whileHover={{ 
-        y: -8, 
+      whileHover={{
+        y: -8,
         scale: 1.02,
         transition: { duration: 0.4, ease: "easeOut" }
       }}
@@ -46,7 +46,7 @@ const BlogCard = ({
       onMouseLeave={() => setIsHovered(false)}
       className="relative overflow-hidden h-full transition-all duration-300"
     >
-      <Link 
+      <Link
         to={`/blog/${id}`}
         className="block h-full text-decoration-none"
         style={{ textDecoration: 'none' }}
@@ -54,17 +54,17 @@ const BlogCard = ({
         <div className="article-card h-full">
           {/* Category Badge */}
           <div className="card-category">{category}</div>
-          
+
           {/* Card Image */}
           <div className="card-image">
             <img src={imageUrl} alt={title} />
           </div>
-          
+
           {/* Card Content */}
           <div className="card-content">
             <h3 className="card-title">{title}</h3>
             <p className="card-description">{content}</p>
-            
+
             {/* Card Meta */}
             <div className="card-meta">
               <div className="card-author">
@@ -73,7 +73,7 @@ const BlogCard = ({
               </div>
               <span className="card-read-time">5 min read</span>
             </div>
-            
+
             {/* Read More Button */}
             <div className="card-read-more">
               Read Article →

--- a/src/components/discussions/DiscussionCard.tsx
+++ b/src/components/discussions/DiscussionCard.tsx
@@ -123,7 +123,7 @@ export default function DiscussionCard({
               }}
             />
           ) : null}
-          <div 
+          <div
             className="author-avatar-fallback"
             style={{ display: discussion.author.avatar_url ? 'none' : 'flex' }}
           >

--- a/src/components/giscus.tsx
+++ b/src/components/giscus.tsx
@@ -1,15 +1,92 @@
+// import React, { useEffect, useRef } from "react";
+
+// const GiscusComments: React.FC = () => {
+//   const ref = useRef<HTMLDivElement>(null);
+
+//   useEffect(() => {
+//     if (!ref.current) return;
+//     // Prevent duplicate script injection
+//     if (ref.current.querySelector("iframe")) return;
+
+//     const script = document.createElement("script");
+//     script.src = "https://giscus.app/client.js";
+//     script.setAttribute("data-repo", "recodehive/Support");
+//     script.setAttribute("data-repo-id", "R_kgDOL9urew");
+//     script.setAttribute("data-category", "General");
+//     script.setAttribute("data-category-id", "DIC_kwDOL9ure84Cqizj");
+//     script.setAttribute("data-mapping", "og:title");
+//     script.setAttribute("data-strict", "0");
+//     script.setAttribute("data-reactions-enabled", "1");
+//     script.setAttribute("data-emit-metadata", "0");
+//     script.setAttribute("data-input-position", "top");
+//     script.setAttribute("data-theme", "preferred_color_scheme");
+//     script.setAttribute("data-lang", "en");
+//     script.crossOrigin = "anonymous";
+//     script.async = true;
+//     ref.current.appendChild(script);
+//   }, []);
+
+//   return <div ref={ref} />;
+// };
+
+// export default GiscusComments;
+
+// import React, { useEffect, useRef } from "react";
+// import { useColorMode } from "@docusaurus/theme-common"
+
+// const GiscusComments: React.FC = () => {
+//   const ref = useRef<HTMLDivElement>(null);
+//   const { colorMode } = useColorMode();
+//   console.log(colorMode)
+//   useEffect(() => {
+//     if (!ref.current) return;
+//     // Prevent duplicate script injection
+//     if (ref.current.querySelector("iframe")) return;
+
+//     const script = document.createElement("script");
+//     script.src = "https://giscus.app/client.js";
+//     script.setAttribute("data-repo", "recodehive/Support");
+//     script.setAttribute("data-repo-id", "R_kgDOL9urew");
+//     script.setAttribute("data-category", "General");
+//     script.setAttribute("data-category-id", "DIC_kwDOL9ure84Cqizj");
+//     script.setAttribute("data-mapping", "og:title");
+//     script.setAttribute("data-strict", "0");
+//     script.setAttribute("data-reactions-enabled", "1");
+//     script.setAttribute("data-emit-metadata", "0");
+//     script.setAttribute("data-input-position", "top");
+
+//     // Set the default theme to "light"
+//     script.setAttribute("data-theme", colorMode);
+
+//     script.setAttribute("data-lang", "en");
+//     script.crossOrigin = "anonymous";
+//     script.async = true;
+//     ref.current.appendChild(script);
+//   }, [colorMode]);
+
+//   return <div ref={ref} />;
+// };
+
+// export default GiscusComments;
+
 import React, { useEffect, useRef } from "react";
+import { useColorMode } from "@docusaurus/theme-common";
 
 const GiscusComments: React.FC = () => {
   const ref = useRef<HTMLDivElement>(null);
+  const { colorMode } = useColorMode(); // colorMode is 'light' or 'dark'
 
+  // 1. This useEffect handles the initial script loading ONCE.
   useEffect(() => {
-    if (!ref.current) return;
-    // Prevent duplicate script injection
-    if (ref.current.querySelector("iframe")) return;
+    // Exit if the ref isn't set or if the script is already there
+    if (!ref.current || ref.current.hasChildNodes()) {
+      return;
+    }
 
     const script = document.createElement("script");
     script.src = "https://giscus.app/client.js";
+    script.async = true;
+    script.crossOrigin = "anonymous";
     script.setAttribute("data-repo", "recodehive/Support");
     script.setAttribute("data-repo-id", "R_kgDOL9urew");
     script.setAttribute("data-category", "General");
@@ -19,12 +96,30 @@ const GiscusComments: React.FC = () => {
     script.setAttribute("data-reactions-enabled", "1");
     script.setAttribute("data-emit-metadata", "0");
     script.setAttribute("data-input-position", "top");
-    script.setAttribute("data-theme", "preferred_color_scheme");
     script.setAttribute("data-lang", "en");
-    script.crossOrigin = "anonymous";
-    script.async = true;
+
+    // Use the initial colorMode from Docusaurus for the initial theme
+    script.setAttribute("data-theme", colorMode);
+
     ref.current.appendChild(script);
-  }, []);
+  }, []); // <-- Empty dependency array ensures this runs only once on mount.
+
+  // 2. This useEffect watches for changes in colorMode and sends a message to Giscus.
+  useEffect(() => {
+    const iframe = ref.current?.querySelector<HTMLIFrameElement>(
+      "iframe.giscus-frame"
+    );
+
+    if (!iframe) {
+      return;
+    }
+
+    // Send a message to the Giscus iframe to update its theme
+    iframe.contentWindow.postMessage(
+      { giscus: { setConfig: { theme: colorMode } } },
+      "https://giscus.app"
+    );
+  }, [colorMode]); // <-- This runs every time colorMode changes.
 
   return <div ref={ref} />;
 };


### PR DESCRIPTION
## Description
The Giscus component did not update its theme when the site's color mode was toggled. The theme was only set once during the initial script injection.

This change implements the recommended approach for dynamic theme updates by:
1.  Using a  hook that runs only once on mount to inject the Giscus script with the initial theme.
2.  Adding a second  hook that listens for changes to .
3.  When a change is detected, it sends a  to the Giscus iframe to update its theme, ensuring it stays in sync with the site's theme toggle.


Fixes #775 and #773 

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Original Behaviour
<img width="779" height="399" alt="image" src="https://github.com/user-attachments/assets/b9d17b00-cf10-43d6-a6a9-0a925abc75cf" />


## Changes Made

**Light Mode** 
<img width="722" height="415" alt="image" src="https://github.com/user-attachments/assets/364c0e8e-94fe-4fdc-931f-d9cf19943bd3" />

**Dark Mode**
<img width="712" height="407" alt="image" src="https://github.com/user-attachments/assets/f6b9edb5-d2c0-401a-abc7-1107c27b38c3" />

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers and devices
- [x] My changes do not generate new console warnings or errors .
- [x] I ran `npm run build` and attached screenshot(s) in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.
