### PR TITLE
fix(giscus): initialize giscus script with correct theme

### DIFF
--- a/src/components/giscus.tsx
+++ b/src/components/giscus.tsx
@@ -83,6 +83,14 @@ const GiscusComments: React.FC = () => {
       return;
     }
 
+    // Use localStorage to get user's last theme or fallback to 'light'
+    const storedTheme =
+      localStorage.getItem("theme") || (
+        document.documentElement.getAttribute("data-theme") === "dark"
+        ? "dark"
+        : "light"
+      );
+
     const script = document.createElement("script");
     script.src = "https://giscus.app/client.js";
     script.async = true;
@@ -99,7 +107,7 @@ const GiscusComments: React.FC = () => {
     script.setAttribute("data-lang", "en");
 
     // Use the initial colorMode from Docusaurus for the initial theme
-    script.setAttribute("data-theme", colorMode);
+    script.setAttribute("data-theme", storedTheme);
 
     ref.current.appendChild(script);
   }, []); // <-- Empty dependency array ensures this runs only once on mount.


### PR DESCRIPTION
## Description

<!-- 
Provide a brief summary of the changes made to the website and the motivation behind them. Include any relevant issues or tickets.
This helps fast tracking your PR and merge it, Check the respective box below.
-->
Fixes the Giscus comments section theme mismatch during page load and hydration. Previously, Giscus would initialize in light mode even on dark-themed sites because the initial theme was read from useColorMode before hydration. This update ensures the correct theme is applied on first render and dynamically updates when the user toggles the site theme.

Fixes #858 

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made

- Initialize Giscus script using localStorage or HTML data-theme to reflect the user’s actual theme on first load.
- Ensures SSR-safe and efficient loading without re-injecting the script multiple times.

<!--
Describe the key changes (e.g., new sections, updated components, responsive fixes).
-->

## Dependencies

- No new dependencies added.
- Works with existing Docusaurus setup and `@docusaurus/theme-common`

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers and devices
- [x] My changes do not generate new console warnings or errors .
- [x] I ran `npm run build` and attached screenshot(s) in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.

<img width="1919" height="970" alt="image" src="https://github.com/user-attachments/assets/29513490-bff4-42f9-828d-7f772d7a8f82" />
