### PR TITLE
chore: add Husky pre-commit hook with lint-staged for ESLint/Prettier

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -17,7 +17,14 @@
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx",
     "lint:fix": "eslint . --ext .ts,.tsx,.js,.jsx --fix",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,css}\"",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "prepare": "husky"
+  },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ]
   },
   "dependencies": {
     "@docusaurus/core": "^3.9.1",
@@ -76,6 +83,8 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
     "eslint-plugin-react": "^7.37.5",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.2.3",
     "postcss": "^8.5.3",
     "prettier": "^3.6.2",
     "tailwindcss": "^4.1.4",


### PR DESCRIPTION
## Description

Add Husky pre-commit hooks integrated with lint-staged to automatically run ESLint and Prettier on staged files before committing. This ensures all code adheres to the project’s linting and formatting rules and reduces the likelihood of linting errors in CI.

Fixes #839 

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [x] Other (please specify): tooling / development workflow improvement

## Changes Made

- Installed **Husky v9** and **lint-staged**.
- Added a `.husky/pre-commit` hook that runs `lint-staged`.
- Configured `lint-staged` in `package.json` to auto-fix staged JS/TS/JSX/TSX files with ESLint and Prettier.
- Added a `prepare` script in `package.json` to ensure Husky hooks are installed automatically.

## Dependencies

- **Husky** `^9.1.7` (dev dependency)
- **lint-staged** `^16.2.3` (dev dependency)
- No other runtime dependencies added

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers and devices
- [x] My changes do not generate new console warnings or errors .
- [x] I ran `npm run build` and attached screenshot(s) in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.

## **Note  for Reviewers:**

- After merging, contributors will automatically run linting/formatting before committing.
- No manual steps are required, but running `npm install` will activate the hooks.

## **How it works:**

- `eslint --fix` runs only on the staged files matching the glob pattern.
- `prettier --write` runs only on those same staged files.
- No need for `git add`, because lint-staged automatically updates the staged files after running the commands.

