### PR TITLE
[FIX]: #968 Duplicate Arrows Appearing After Link Text in GitHub Badges 

### DIFF
--- a/src/pages/badges/github-badges.tsx
+++ b/src/pages/badges/github-badges.tsx
@@ -1122,7 +1122,7 @@ const GithubBadgesContent = (): React.ReactElement => {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Prepare for the GitHub Foundations exam →
+                Prepare for the GitHub Foundations exam
               </a>
             </div>
             <div className={styles.certBadge}>
@@ -1163,7 +1163,7 @@ const GithubBadgesContent = (): React.ReactElement => {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Prepare for the GitHub Actions exam →
+                Prepare for the GitHub Actions exam
               </a>
             </div>
           </motion.div>
@@ -1189,7 +1189,7 @@ const GithubBadgesContent = (): React.ReactElement => {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Prepare for the GitHub Advanced Security exam →
+                Prepare for the GitHub Advanced Security exam
               </a>
             </div>
             <div className={styles.certBadge}>
@@ -1229,7 +1229,7 @@ const GithubBadgesContent = (): React.ReactElement => {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Prepare for the GitHub Administration exam →
+                Prepare for the GitHub Administration exam
               </a>
             </div>
           </motion.div>
@@ -1255,7 +1255,7 @@ const GithubBadgesContent = (): React.ReactElement => {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Coming Soon! Join the waitlist now for priority access →
+                Coming Soon! Join the waitlist now for priority access
               </a>
             </div>
             <div className={styles.certBadge}>


### PR DESCRIPTION
## Description

<!-- 
Provide a brief summary of the changes made to the website and the motivation behind them. Include any relevant issues or tickets.
This helps fast tracking your PR and merge it, Check the respective box below.
-->
Fixes #968 

This PR fixes the issue where **duplicate arrows appear after the link text** in the GitHub achievement badges section. One arrow was coming from the CSS styling and another was hardcoded in the HTML. The PR removes the hardcoded arrow to ensure only a **single arrow** appears, improving visual consistency and readability.


https://github.com/user-attachments/assets/d4bf7859-6572-4c4d-b321-6e47c403b560


## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made

<!--
Describe the key changes (e.g., new sections, updated components, responsive fixes).
-->
- Removed the hardcoded arrow (`→`) from the innerHTML of GitHub badge links.  
- Verified that CSS  styling provides the single arrow consistently.  
- Tested the layout in both light and dark modes to ensure uniform appearance.  
- Ensured no duplicate arrows appear after link text.  

## Dependencies

- No new dependencies introduced.  
- No version updates required.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers and devices.
- [x] My changes do not generate new console warnings or errors.
- [x] I ran `npm run build` and attached screenshot(s) in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.
