### PR TITLE
fix(ui): update Pro Tips section color scheme

### DIFF
--- a/src/pages/interview-prep/TechnicalTab.tsx
+++ b/src/pages/interview-prep/TechnicalTab.tsx
@@ -385,7 +385,7 @@ const TechnicalTab: React.FC<TechnicalTabProps> = ({
 
       {/* Tips & Best Practices */}
       <motion.div
-        className="rounded-2xl bg-gradient-to-r from-blue-50 to-purple-50 p-8 dark:from-gray-800 dark:to-gray-700"
+        className="rounded-2xl border border-blue-100 bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50 p-8 dark:border-blue-800 dark:from-blue-900/20 dark:via-indigo-900/20 dark:to-purple-900/20"
         variants={fadeIn}
       >
         <h3 className="mb-6 text-center text-2xl font-bold text-gray-900 dark:text-white">
@@ -394,7 +394,7 @@ const TechnicalTab: React.FC<TechnicalTabProps> = ({
         <div className="grid gap-6 md:grid-cols-2">
           <div className="space-y-4">
             <div className="flex items-start space-x-3">
-              <div className="mt-1 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-blue-500">
+              <div className="mt-1 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-indigo-500">
                 <span className="text-xs font-bold text-white">1</span>
               </div>
               <div>
@@ -408,7 +408,7 @@ const TechnicalTab: React.FC<TechnicalTabProps> = ({
               </div>
             </div>
             <div className="flex items-start space-x-3">
-              <div className="mt-1 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-blue-500">
+              <div className="mt-1 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-indigo-500">
                 <span className="text-xs font-bold text-white">2</span>
               </div>
               <div>
@@ -422,7 +422,7 @@ const TechnicalTab: React.FC<TechnicalTabProps> = ({
               </div>
             </div>
             <div className="flex items-start space-x-3">
-              <div className="mt-1 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-blue-500">
+              <div className="mt-1 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-indigo-500 to-purple-500">
                 <span className="text-xs font-bold text-white">3</span>
               </div>
               <div>
@@ -438,7 +438,7 @@ const TechnicalTab: React.FC<TechnicalTabProps> = ({
           </div>
           <div className="space-y-4">
             <div className="flex items-start space-x-3">
-              <div className="mt-1 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-purple-500">
+              <div className="mt-1 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-indigo-500 to-purple-500">
                 <span className="text-xs font-bold text-white">4</span>
               </div>
               <div>
@@ -452,7 +452,7 @@ const TechnicalTab: React.FC<TechnicalTabProps> = ({
               </div>
             </div>
             <div className="flex items-start space-x-3">
-              <div className="mt-1 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-purple-500">
+              <div className="mt-1 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-purple-500 to-pink-500">
                 <span className="text-xs font-bold text-white">5</span>
               </div>
               <div>
@@ -465,7 +465,7 @@ const TechnicalTab: React.FC<TechnicalTabProps> = ({
               </div>
             </div>
             <div className="flex items-start space-x-3">
-              <div className="mt-1 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-purple-500">
+              <div className="mt-1 flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-purple-500 to-pink-500">
                 <span className="text-xs font-bold text-white">6</span>
               </div>
               <div>


### PR DESCRIPTION
- Aligned background gradient with site theme (blue-indigo-purple)
- Added gradient progression to number badges (blue→indigo→ number badges (blue→indigo→purple→pink)
- Improved dark mode support with proper

## Description
fixes: https://github.com/recodehive/recode-website/issues/985

## Type of Change

- [x] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made

Light mode:

<img width="1402" height="492" alt="image" src="https://github.com/user-attachments/assets/b9a0cea1-89ae-4331-9ad6-55c6f44ee155" />


Dark mode: 

<img width="1403" height="485" alt="image" src="https://github.com/user-attachments/assets/fefce6be-46f3-4798-90a6-bc63ab18f3b3" />


## Dependencies

- List any new dependencies or tools required for this change.
- Mention any version updates or configurations that need to be considered.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers and devices
- [x] My changes do not generate new console warnings or errors .
- [x] I ran `npm run build` and attached screenshot(s) in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.
