### PR TITLE
[FIX]: #976 Podcast Page Stats Title Not Visible in Light Mode 

### DIFF
--- a/src/pages/podcasts/index.css
+++ b/src/pages/podcasts/index.css
@@ -291,7 +291,16 @@ html[data-theme="light"] {
 
 .stat-label {
   font-size: 14px;
-  color: var(--podcast-text-dim);
+  background: linear-gradient(
+    135deg,
+    var(--podcast-text-primary) 0%,
+    var(--podcast-text-secondary) 30%,
+    var(--podcast-text-muted) 60%,
+    var(--podcast-text-dim) 100%
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.5px;


### PR DESCRIPTION
## Description

Fixes #976  

This PR addresses the issue on the **Podcast page** where the stats title (Episodes, Hours, Shows) was **not visible in light mode** because the white text blended into the background.  

The changes update the styling of the stats title so that it now uses a **linear gradient effect** that ensures the text is **clearly visible in both light and dark themes**. This makes the titles stand out, improves readability, and adds a visually appealing style to the page.

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)  
- [ ] Bug fix (non-breaking change that fixes an issue)  
- [x] UI/UX improvement (design, layout, or styling updates)  
- [ ] Performance optimization (e.g., code splitting, caching)  
- [ ] Documentation update (README, contribution guidelines, etc.)  
- [ ] Other (please specify):  

## Changes Made

- Updated the Podcast stats title styling so that the text is **readable and visually appealing** in both light and dark themes.  
- Ensured the text stands out and does not blend into the background in light mode.  
- Maintained a **consistent look** across different themes while preserving the design aesthetics.  
- Tested on Chrome to confirm that the titles are visible and the gradient effect works as intended.  

https://github.com/user-attachments/assets/401dd1a1-8791-42dc-aaf1-bcc104d9b5f4



## Dependencies

- No new dependencies introduced.  
- No version updates required.  

## Checklist

- [x] My code follows the style guidelines of this project.  
- [x] I have tested my changes across major browsers and devices.  
- [x] My changes do not generate new console warnings or errors.  
- [x] I ran `npm run build` and attached screenshot(s) in this PR.  
- [x] This is already assigned Issue to me, not an unassigned issue.
