### PR TITLE
[FIX]: #1072 Explore Ebooks Search Bar Text Color Not Responsive to Theme

### DIFF
--- a/src/pages/ebooks/index.css
+++ b/src/pages/ebooks/index.css
@@ -61,14 +61,14 @@
   border-radius: 12px;
   border: 1px solid var(--ifm-toc-border-color);
   font-size: 1rem;
-  color: var(--ifm-font-color-base);
   background-color: var(--ifm-background-color);
+  color: var(--ifm-heading-color);
   box-shadow: var(--ifm-global-shadow-lw);
   transition: all 0.25s ease;
 }
 
 .ebook-search-wrapper input.ebook-search::placeholder {
-  color: var(--ifm-color-muted); 
+  color: var(--ifm-heading-color);
   opacity: 0.6;
 }
 


### PR DESCRIPTION
## Description

Fixes #1072 

This PR addresses the bug in the Explore Ebooks section where the search bar text and placeholder color are not responsive to the selected theme. In dark mode, the text appears black on a dark background, making it hard to read. The change ensures that the input text and placeholder dynamically adapt to the active theme for better readability.

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)  
- [x] Bug fix (non-breaking change that fixes an issue)  
- [x] UI/UX improvement (design, layout, or styling updates)  
- [ ] Performance optimization (e.g., code splitting, caching)  
- [ ] Documentation update (README, contribution guidelines, etc.)  
- [ ] Other (please specify):  

## Changes Made

- Updated `.ebook-search-wrapper input.ebook-search` to use theme-aware color variables instead of fixed colors.  
- Ensured placeholder and input text dynamically respond to light and dark modes.  
- Verified that text contrast is adequate for readability in both themes.  

## Dependencies

- No new dependencies were added.  
- No version updates required.  

## Checklist

- [x] My code follows the style guidelines of this project.  
- [x] I have tested my changes across major browsers and devices.  
- [x] My changes do not generate new console warnings or errors.  
- [x] I ran `npm run build` and attached screenshot(s) in this PR.  
- [x] This is already assigned Issue to me, not an unassigned issue.  
