### PR TITLE
[FIX]: #1073 Podcast Page “No Podcasts Found” and Suggestion Text Displayed on Single Line 

### DIFF
--- a/src/pages/podcasts/index.css
+++ b/src/pages/podcasts/index.css
@@ -793,6 +793,8 @@ html[data-theme="light"] {
 
 /* No Results */
 .no-results {
+  display: flex;
+  flex-direction: column;
   text-align: center;
   padding: 80px 20px;
   max-width: 400px;
@@ -801,15 +803,14 @@ html[data-theme="light"] {
 
 .no-results-icon {
   font-size: 64px;
-  margin-bottom: 24px;
   opacity: 0.6;
+  margin: 0; /* removes default browser margin */
 }
 
 .no-results h3 {
   font-size: 24px;
   font-weight: 700;
   color: var(--podcast-text-primary);
-  margin-bottom: 12px;
 }
 
 .no-results p {


### PR DESCRIPTION
## Description

Fixes #1073

This PR addresses the bug on the Podcast page where the “No Podcasts Found” message and the suggestion text (“Try adjusting your search or filters…”) are displayed on a single line. The change ensures that both messages appear on separate lines for better readability and UI clarity.

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)  
- [x] Bug fix (non-breaking change that fixes an issue)  
- [x] UI/UX improvement (design, layout, or styling updates)  
- [ ] Performance optimization (e.g., code splitting, caching)  
- [ ] Documentation update (README, contribution guidelines, etc.)  
- [ ] Other (please specify):  

## Changes Made

- Updated Podcast page layout/CSS to force the two messages onto separate lines.  
- Verified text appearance across light and dark modes.  
- Ensured responsive design for different screen sizes.  
<img width="713" height="288" alt="Screenshot 2025-10-26 at 3 54 57 PM" src="https://github.com/user-attachments/assets/156c6e08-4577-47e2-a909-661b33d1c5d9" />



## Dependencies

- No new dependencies were added.  
- No version updates required.  

## Checklist

- [x] My code follows the style guidelines of this project.  
- [x] I have tested my changes across major browsers and devices.  
- [x] My changes do not generate new console warnings or errors.  
- [x] I ran `npm run build` and attached screenshot(s) in this PR.  
- [x] This is already assigned Issue to me, not an unassigned issue.  
