### PR TITLE
fix(ui): reapply author profile CSS patches and resolve blog page overlap conflicts

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1769,7 +1769,27 @@ html[data-theme="light"] [data-slot="card-header"].bg-gradient-to-br {
 }
 
 @media screen and (max-width: 1110px) {
-  .navbar__items{
+  .navbar__items {
     gap: 0.1rem !important;
+  }
 }
+
+/* Fix for author page avatar overlap - working solution */
+.avatar.margin-bottom--sm.author-as-h1_iMAg {
+  width: 150px !important;
+  height: 150px !important;
+  border-radius: 50% !important;
+  border: none !important;
+}
+
+
+.avatar.margin-bottom--sm {
+  width: auto !important;
+  height: auto !important;
+  border: none !important;
+}
+
+
+.blog-page .margin-bottom--xl {
+  margin-bottom: 0rem !important;
 }


### PR DESCRIPTION
This PR reintroduces the previous CSS patches for the author profile section that were accidentally overridden by subsequent PRs.
The issue caused overlapping of the author image, name, and bio on blog and author pages.
The layout has been adjusted to restore proper alignment and prevent CSS conflicts with blog templates.

Fixes #1054

---

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [x] UI/UX improvement (design, layout, or styling updates)

---

## Changes Made

* Reapplied missing CSS rules for author profile layout.
* Adjusted margins and positioning to prevent overlap with name and bio text.
* Resolved CSS conflicts with the blog page components.
* Verified consistency across different author pages and blog entries.

---

## Dependencies

No new dependencies added or modified.

---

## Checklist

* [x] My code follows the style guidelines of this project.
* [x] I have tested my changes across major browsers and devices.
* [x] My changes do not generate new console warnings or errors.
* [x] I ran `npm run build` and attached screenshots in this PR.
* [x] This is already an assigned issue to me, not an unassigned issue.