### PR TITLE
Refix: Home icon alignment in Docs breadcrumbs

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1602,7 +1602,7 @@ a {
 
 /* ================= MISCELLANEOUS ================= */
 /* Fix Home icon alignment with text in breadcrumbs [Docs] */
-.theme-doc-breadcrumbs a.breadcrumbs__link>svg.breadcrumbHomeIcon_YNFT {
+.theme-doc-breadcrumbs a.breadcrumbs__link > svg {
   display: inline-block;
 }
 


### PR DESCRIPTION
## Description

<!-- 
Provide a brief summary of the changes made to the website and the motivation behind them. Include any relevant issues or tickets.
This helps fast tracking your PR and merge it, Check the respective box below.
-->
Fixes #691 

Follow-up for PR #719 

The earlier fix targeted a specific hashed class name (.breadcrumbHomeIcon_YNFT), which has since changed and caused alignment issue to reappear.

<img width="1180" height="183" alt="recode-issue" src="https://github.com/user-attachments/assets/349b25a8-934e-4dde-a46c-8a2cafab6efd" />

<img width="830" height="152" alt="recode-issue - refix" src="https://github.com/user-attachments/assets/eef952ce-f964-4b4c-a742-5c9538c48305" />

---

**Updated the selector to target the <svg> element directly, so the rule keeps working even if class names change in the future.**

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made

<!--
Describe the key changes (e.g., new sections, updated components, responsive fixes).
-->

`.theme-doc-breadcrumbs a.breadcrumbs__link > svg.breadcrumbHomeIcon_YNFT { ... } `

changed to 

`.theme-doc-breadcrumbs a.breadcrumbs__link > svg { ... }`

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers and devices
- [x] My changes do not generate new console warnings or errors .
- [x] I ran `npm run build` and attached screenshot(s) in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.