### PR TITLE
fix: adjust MIT license page content width for better readability   

### DIFF
--- a/src/pages/License/index.css
+++ b/src/pages/License/index.css
@@ -176,7 +176,7 @@ html[data-theme="light"] {
 .lic-content-wrapper {
   position: relative;
   z-index: 1;
-  max-width: 1200px;
+  max-width: 900px;
   margin: 0 auto;
   padding: 4rem 1.5rem;
   animation: fadeInUp 0.8s ease-out;


### PR DESCRIPTION
This PR adjusts the width of the MIT license page content area to improve readability and match the design requirements.

fixes : #1136

## 🔧 Changes Made

- Updated `.lic-content-wrapper` max-width from `1200px` to `900px` in `src/pages/License/index.css`
- This creates a narrower, more readable content area with better side margins

## 📸 Screenshots

<img width="1470" height="772" alt="Screenshot 2025-11-07 at 10 38 34 PM" src="https://github.com/user-attachments/assets/97e604b3-ea44-4ccc-a0eb-7162b9cdb946" />
