### PR TITLE
Fix(UI/UX): Permanently display ebook card action buttons

### DIFF
--- a/src/pages/ebooks/index.css
+++ b/src/pages/ebooks/index.css
@@ -508,15 +508,11 @@ html[data-theme="light"] {
 .card-actions {
   display: flex;
   gap: 8px;
-  opacity: 0;
+  opacity: 1 !important;
   transition: opacity 0.3s ease;
   position: relative;
   z-index: 10;
-  pointer-events: auto;
-}
-
-.enhanced-ebook-card:hover .card-actions {
-  opacity: 1;
+  pointer-events: auto !important;
 }
 
 .action-btn.share {
@@ -687,14 +683,8 @@ html[data-theme="light"] {
   font-size: 14px;
   cursor: pointer;
   transition: all 0.3s ease;
-  opacity: 0;
   transform: translateY(10px);
   align-self: flex-start;
-}
-
-.enhanced-ebook-card:hover .ebook-read-button {
-  opacity: 1;
-  transform: translateY(0);
 }
 
 .ebook-read-button:hover {


### PR DESCRIPTION
## Description

This PR ensures that all buttons (Favorite, Share, and Read Now) on the ebook cards are permanently visible by default, removing the requirement for the user to hover over the card.
Fixes #1167 

## Type of Change

- [x] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made

- Removed hover rules and set `opacity: 1 !important` for permanent visibility via `.card-actions`.
- Removed hover rules and initial hidden transformations from `.ebook-read-button` to ensure constant visibility

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers and devices
- [x] My changes do not generate new console warnings or errors .
- [x] I ran `npm run build` and attached screenshot(s) in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.
