### PR TITLE
Fix: Adjusted height of 1st top performer

### DIFF
--- a/src/components/dashboard/LeaderBoard/leaderboard.css
+++ b/src/components/dashboard/LeaderBoard/leaderboard.css
@@ -114,7 +114,7 @@
 }
 
 /* Staircase Height Adjustment */
-.first-place { transform: translateY(-60px); }
+.first-place { transform: translateY(-30px); }
 .second-place { transform: translateY(0px); }
 .third-place { transform: translateY(0px); }
 
@@ -249,7 +249,7 @@
 }
 
 .first-place:hover {
-  transform: translateY(-65px);
+  transform: translateY(-35px);
   border-color: #FFD700;
   box-shadow: 0 0 15px rgba(255, 215, 0, 0.7), 0 10px 30px rgba(0, 0, 0, 0.15);
 }


### PR DESCRIPTION
## Description

This PR lowers down the 1st top performer card in podium
Fixes #1190 

## Type of Change

- [x] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made

- Changed original position from -60px to -30px
- Changed translateY(-65px) to translateY(-35px) for consistent UI/UX

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers and devices
- [x] My changes do not generate new console warnings or errors .
- [x] I ran `npm run build` and attached screenshot(s) in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.

## Attachment

<img width="1165" height="548" alt="Screenshot 2025-11-12 224105" src="https://github.com/user-attachments/assets/88b035e2-b62a-4fb5-be39-cc477b6b25d9" />
