### PR TITLE
Changed docker icon to green

### DIFF
--- a/src/theme/DocSidebarItem/Category/styles.module.css
+++ b/src/theme/DocSidebarItem/Category/styles.module.css
@@ -75,7 +75,7 @@
 }
 
 .dockerIcon {
-  color: #2196f3;
+  color: #38a169;
 }
 
 .technicalIcon {
@@ -227,7 +227,7 @@
 }
 
 .custom-sidebar-docker .categoryLink .categoryIcon {
-  color: #2196f3;
+  color: #38a169;
 }
 
 .custom-sidebar-technical .categoryLink .categoryIcon {


### PR DESCRIPTION

Fixes #1229 

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)


## Changes Made

Changed docker icon to green
screenshot:
Before :
<img width="395" height="414" alt="image" src="https://github.com/user-attachments/assets/8a8cbfc0-710a-4d1d-bf1b-468fd92feaa3" />
After
<img width="338" height="311" alt="image" src="https://github.com/user-attachments/assets/b9a9e5e8-fba9-4440-b305-bdaa63cade10" />


## Checklist

- [X] My code follows the style guidelines of this project.
- [X] I have tested my changes across major browsers and devices
- [X] My changes do not generate new console warnings or errors .
- [X] I ran `npm run build` and attached screenshot(s) in this PR.
- [X] This is already assigned Issue to me, not an unassigned issue.
