### PR TITLE
Fix Algolia search button alignment

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -276,7 +276,7 @@ const config: Config = {
         max: 1030,
         min: 640,
         steps: 2,
-        disableInDev: false,
+        disableInDev: true,
       },
     ],
   ],

--- a/src/components/AlgoliaSiteSearch/index.tsx
+++ b/src/components/AlgoliaSiteSearch/index.tsx
@@ -23,6 +23,7 @@ declare global {
         applicationId: string;
         apiKey: string;
         indexName: string;
+        insights?: boolean;
         attributes: {
           primaryText: string;
           secondaryText: string;
@@ -32,6 +33,7 @@ declare global {
         };
         darkMode: boolean;
       }) => void;
+      destroy?: (container: string) => void;
     };
   }
 }
@@ -115,6 +117,7 @@ export default function AlgoliaSiteSearch(): React.ReactElement | null {
           applicationId,
           apiKey,
           indexName,
+          insights: false,
           attributes: {
             primaryText: "title",
             secondaryText: "description",
@@ -131,6 +134,7 @@ export default function AlgoliaSiteSearch(): React.ReactElement | null {
 
     return () => {
       cancelled = true;
+      window.SiteSearch?.destroy?.(`#${containerId}`);
     };
   }, [apiKey, applicationId, indexName, isConfigured]);
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1388,6 +1388,59 @@ html {
   box-sizing: border-box !important;
 }
 
+.algolia-sitesearch-navbar {
+  display: flex !important;
+  align-items: center !important;
+  padding: 0.2rem 0.3rem !important;
+}
+
+.algolia-sitesearch-navbar #algolia-sitesearch-navbar {
+  display: flex;
+  align-items: center;
+}
+
+.algolia-sitesearch-navbar .sitesearch-button {
+  display: flex !important;
+  align-items: center !important;
+  height: 36px !important;
+  min-width: 250px;
+  padding: 0.5rem 0.75rem !important;
+  gap: 0.5rem !important;
+  transform: none !important;
+}
+
+.algolia-sitesearch-navbar .sitesearch-button:hover {
+  transform: none !important;
+}
+
+.algolia-sitesearch-navbar .sitesearch-button .search-icon {
+  position: static !important;
+  inset: auto !important;
+  display: inline-flex !important;
+  align-self: center !important;
+  flex: 0 0 18px;
+  width: 18px;
+  height: 18px;
+  margin: 0 !important;
+  line-height: 0 !important;
+  pointer-events: none;
+}
+
+.algolia-sitesearch-navbar .sitesearch-button .search-icon svg {
+  display: block;
+  width: 18px !important;
+  height: 18px !important;
+  margin: 0 !important;
+}
+
+.algolia-sitesearch-navbar .sitesearch-button .button-text {
+  min-width: 0;
+}
+
+.algolia-sitesearch-navbar .sitesearch-button .keyboard-shortcut {
+  flex-shrink: 0;
+}
+
 [data-theme="dark"] .explore-btn:hover {
   color: white;
 }

--- a/static/pinterest-init.js
+++ b/static/pinterest-init.js
@@ -1,20 +1,29 @@
 console.log("✅ pinterest-init.js loaded");
-!(function (e) {
-  if (!window.pintrk) {
-    window.pintrk = function () {
-      window.pintrk.queue.push(Array.prototype.slice.call(arguments));
-    };
-    var n = window.pintrk;
-    ((n.queue = []), (n.version = "3.0"));
-    var t = document.createElement("script");
-    t.async = !0;
-    t.src = e;
-    var r = document.getElementsByTagName("script")[0];
-    r.parentNode.insertBefore(t, r);
-  }
-})("https://s.pinimg.com/ct/core.js");
 
-pintrk("load", "2613717138491", {
-  em: "b58906c504c5638798eb06151e6f49af1b0e4c6c3b5d4f30d9c2268dbe6f9d60", // example hashed email
-});
-pintrk("page");
+const isLocalhost = ["localhost", "127.0.0.1", "::1"].includes(
+  window.location.hostname,
+);
+
+if (isLocalhost) {
+  console.log("Pinterest tracking skipped in local development");
+} else {
+  !(function (e) {
+    if (!window.pintrk) {
+      window.pintrk = function () {
+        window.pintrk.queue.push(Array.prototype.slice.call(arguments));
+      };
+      var n = window.pintrk;
+      ((n.queue = []), (n.version = "3.0"));
+      var t = document.createElement("script");
+      t.async = !0;
+      t.src = e;
+      var r = document.getElementsByTagName("script")[0];
+      r.parentNode.insertBefore(t, r);
+    }
+  })("https://s.pinimg.com/ct/core.js");
+
+  pintrk("load", "2613717138491", {
+    em: "b58906c504c5638798eb06151e6f49af1b0e4c6c3b5d4f30d9c2268dbe6f9d60", // example hashed email
+  });
+  pintrk("page");
+}


### PR DESCRIPTION
## Summary
- Keep the Algolia SiteSearch icon inside the navbar search button and preserve click/focus behavior.
- Disable Algolia insights for this navbar search to avoid fetch-based runtime overlays in dev.
- Skip Pinterest tracking on localhost and disable Ideal Image in dev to avoid local runtime overlays.

Closes #1405

## Testing
- npm run build
- Local browser CDP check: search icon remains within the button, clicking opens the modal and focuses the input, no Failed to fetch runtime exception.