### PR TITLE
Updated View Curriculum as Postman Certification with yt link

### DIFF
--- a/src/components/topmate/TopMateCard.tsx
+++ b/src/components/topmate/TopMateCard.tsx
@@ -33,12 +33,15 @@ const TopMateCard: React.FC<TopMateCardProps> = ({
           : "border-gray-200/50 bg-white/80 shadow-lg"
       }`}
     >
-      {/* Gradient Background */}
-      <div className="absolute inset-0 bg-gradient-to-br from-blue-500/5 via-purple-500/5 to-pink-500/5" />
-      
-      {/* Floating Elements */}
-      <div className="absolute -top-2 -right-2 h-20 w-20 rounded-full bg-gradient-to-br from-blue-400/20 to-purple-600/20 blur-xl" />
-      <div className="absolute -bottom-2 -left-2 h-16 w-16 rounded-full bg-gradient-to-tr from-green-400/20 to-blue-600/20 blur-xl" />
+      {/* Gradient Background (hidden in dark mode) */}
+      {!isDark && (
+        <>
+          <div className="absolute inset-0 bg-gradient-to-br from-blue-500/5 via-purple-500/5 to-pink-500/5" />
+          {/* Floating Elements */}
+          <div className="absolute -top-2 -right-2 h-20 w-20 rounded-full bg-gradient-to-br from-blue-400/20 to-purple-600/20 blur-xl" />
+          <div className="absolute -bottom-2 -left-2 h-16 w-16 rounded-full bg-gradient-to-tr from-green-400/20 to-blue-600/20 blur-xl" />
+        </>
+      )}
 
       <div className="relative p-8">
         {/* Header Badge */}

--- a/src/pages/courses/index.tsx
+++ b/src/pages/courses/index.tsx
@@ -463,7 +463,7 @@ function CoursesContent() {
             >
               Transform Your Career
               <br className="hidden md:block" />
-              <span className="block md:inline">in Data Engineering</span>
+              <span className="block md:inline">in Engineering</span>
             </motion.h1>
             <div className="flex w-full justify-center">
               <motion.p
@@ -503,12 +503,14 @@ function CoursesContent() {
                   </svg>
                 </span>
               </a>
-              <button
+              <a
+                href="https://www.youtube.com/watch?v=O1ahDsq8DU0&list=PLrLTYhoDFx-k62rLLajSB-jeqKwLkDrkF"
+                target="_blank"
+                rel="noopener noreferrer"
                 className="courses-button-secondary group relative overflow-hidden rounded-2xl px-8 py-3 text-base font-bold shadow-2xl transition-all duration-300 hover:scale-105 md:px-10 md:py-4 md:text-lg"
-                onClick={() => handleAction("curriculum")}
               >
                 <span className="relative z-10 flex items-center justify-center gap-2">
-                  View Curriculum
+                  Postman Certification
                   <svg
                     className="h-4 w-4 transition-transform group-hover:translate-x-1 md:h-5 md:w-5"
                     fill="none"
@@ -523,7 +525,7 @@ function CoursesContent() {
                     />
                   </svg>
                 </span>
-              </button>
+              </a>
             </motion.div>
           </div>
 
@@ -785,9 +787,11 @@ function CoursesContent() {
                     </motion.div>
                   </React.Fragment>
                 ))}
-                <motion.button
+                <motion.a
+                  href="https://www.youtube.com/watch?v=GrTV59Y84S8&list=PLrLTYhoDFx-kiuFiGQqVpYYZ56pIhUW63"
+                  target="_blank"
+                  rel="noopener noreferrer"
                   className="courses-button-primary relative z-10 mt-8 transform rounded-2xl px-8 py-3 shadow-2xl transition-all duration-300 hover:scale-110 xl:mt-12 xl:px-10 xl:py-4"
-                  onClick={() => handleAction("enroll")}
                   initial={{ opacity: 0, y: 20 }}
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true }}
@@ -795,8 +799,8 @@ function CoursesContent() {
                   whileHover={{ y: -5 }}
                   whileTap={{ y: 0 }}
                 >
-                  Enroll now
-                </motion.button>
+                  Learn now
+                </motion.a>
               </div>
               {/* Right column */}
               <div className="flex flex-1 flex-col gap-6 lg:gap-8">


### PR DESCRIPTION
## Description

This PR renames 2 buttons namely "Enroll Now" and "View Curriculum" with "Learn Now" and "Postman Certification" along with YouTube links of respective topics. Also then line containing "Data Engineering" is changed to just "Engineering" on courses section.

Fixes #1411
Fixes #1412
Fixes #1416 

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [x] Other (please specify):
- [x] Embedding links under buttons after renaming buttons

## Changes Made

- Changed `Data Engineering` to `Engineering`
- Changed `View Curriculum` button to `Postman Certification` button with YouTube link of same
- Changed `Enroll Now` button to `Learn Now` button with YouTube link of same

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers and devices
- [x] My changes do not generate new console warnings or errors .
- [x] I ran `npm run build` and attached screenshot(s) in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.
 
Issue #1412 and issue #1416 weren't assigned to me originally but all the code were on same place and just minor change I completed them as well with my originally assigned issue #1411

## Attachment(s)

https://github.com/user-attachments/assets/628b2635-59eb-4aeb-910f-74392c7ebbb1