### PR TITLE
Resolves broken Interview Prep navbar links and add missing pages

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -154,7 +154,7 @@ const config: Config = {
                    <a href="/interview-prep/?tab=technical" target="_self" class="nav__icons"> 🧩Technical </a>
                    <a href="/interview-prep/?tab=behavioral" target="_self" class="nav__icons"> 💡Behavioral </a>
                    <a href="/interview-prep/?tab=companies" target="_self" class="nav__icons"> 🏢Companies </a>
-                   <a href="/interview-prep/?tab=practice" target="_self" class="nav__icons"> 🎯Projects </a>
+                   <a href="/interview-prep/?tab=practice" target="_self" class="nav__icons"> 🎯Practice </a>
                  </div>
                </div>`,
             },

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -151,8 +151,10 @@ const config: Config = {
               value: `<div class="grid grid-cols-3 gap-4">
                  <a class="border-r col-span-1" href="/interview-prep/" target="_self">Interview Prep</a>
                  <div class="grid grid-cols-1 col-span-2">
-                   <a href="/interview-prep/" target="_self" class="nav__icons"> 🧩Technical </a>
-                   <a href="/interview-prep/" target="_self" class="nav__icons"> 💡Behavioral </a>
+                   <a href="/interview-prep/?tab=technical" target="_self" class="nav__icons"> 🧩Technical </a>
+                   <a href="/interview-prep/?tab=behavioral" target="_self" class="nav__icons"> 💡Behavioral </a>
+                   <a href="/interview-prep/?tab=companies" target="_self" class="nav__icons"> 🏢Companies </a>
+                   <a href="/interview-prep/?tab=practice" target="_self" class="nav__icons"> 🎯Projects </a>
                  </div>
                </div>`,
             },

--- a/src/pages/interview-prep/index.tsx
+++ b/src/pages/interview-prep/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Layout from "@theme/Layout";
 import Head from "@docusaurus/Head";
 import { motion } from "framer-motion";
@@ -39,6 +39,23 @@ const InterviewPrepPage: React.FC = () => {
   const [expandedCategories, setExpandedCategories] = useState<{
     [key: string]: boolean;
   }>({});
+
+  // Handle URL-based tab navigation
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const params = new URLSearchParams(window.location.search);
+      const tabParam = params.get("tab");
+      if (
+        tabParam &&
+        ["overview", "technical", "behavioral", "companies", "practice"].includes(
+          tabParam
+        )
+      ) {
+        setActiveTab(tabParam as TabType);
+      }
+    }
+  }, []);
+
   const toggleCategory = (categoryIndex: number) => {
     setExpandedCategories((prev) => ({
       ...prev,


### PR DESCRIPTION
## Description

This PR includes Companies and Projects in Interview Prep dropdown. Also redirect their buttons to their respective pages

Fixes #1475 

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made

- Redirects navbar buttons on Interview Prep dropdown to their respective page

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers and devices
- [x] My changes do not generate new console warnings or errors .
- [x] I ran `npm run build` and attached screenshot(s) in this PR.
- [ ] This is already assigned Issue to me, not an unassigned issue.