### PR TITLE
fix: make navbar docs link clickable (#1543)

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -115,6 +115,7 @@ const config: Config = {
           type: "dropdown",
           html: '<span class="nav-emoji">📚</span> Docs',
           position: "left",
+          to: "/docs/",
           items: [
             {
               type: "html",


### PR DESCRIPTION
## Description

Fixes #1543 

Added `to: "/docs/"` to the "Docs" navbar dropdown so the label acts as a clickable link to the docs landing page, while preserving dropdown functionality on hover.

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made

- Added `to: "/docs/"` to the Docs item in `docusaurus.config.ts`.

## Dependencies

- None

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers and devices
- [x] My changes do not generate new console warnings or errors.
- [x] I ran `npm run build` and attached screenshot(s) in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.
