### PR TITLE
fix: calculate actual read time and improve read time UI on blog cards

### DIFF
--- a/src/components/blogCarousel/blogCard.tsx
+++ b/src/components/blogCarousel/blogCard.tsx
@@ -134,7 +134,9 @@ const BlogCard = ({
                 ))}
               </div>
             </div>
-            <span className="card-read-time">5 min read</span>
+            <span className="card-read-time">
+  🕒 {Math.max(1, Math.ceil(content.split(" ").length / 200))} min read
+</span>
           </div>
 
           {/* Read More Button */}

--- a/src/components/blogCarousel/blogCard.tsx
+++ b/src/components/blogCarousel/blogCard.tsx
@@ -135,7 +135,7 @@ const BlogCard = ({
               </div>
             </div>
             <span className="card-read-time">
-  🕒 {Math.max(1, Math.ceil(content.split(" ").length / 200))} min read
+            {Math.max(1, Math.ceil(content.split(" ").length / 200))} min read
 </span>
           </div>
 

--- a/src/pages/blogs/index.tsx
+++ b/src/pages/blogs/index.tsx
@@ -341,7 +341,7 @@ const BlogCard = ({ blog }: { blog: (typeof blogs)[number] }) => {
           </div>
           <span className="card-read-time">
   <span className="card-read-time">
-  🕒 {Math.max(1, Math.ceil((blog.content || "").split(" ").length / 200))} min read
+  {Math.max(1, Math.ceil((blog.content || "").split(" ").length / 200))} min read
 </span>
 </span>
         </div>

--- a/src/pages/blogs/index.tsx
+++ b/src/pages/blogs/index.tsx
@@ -339,7 +339,9 @@ const BlogCard = ({ blog }: { blog: (typeof blogs)[number] }) => {
               ))}
             </div>
           </div>
-          <span className="card-read-time">5 min read</span>
+          <span className="card-read-time">
+  🕒 {Math.max(1, Math.ceil((item.content || "").split(" ").length / 200))} min read
+</span>
         </div>
         <Link to={`/blog/${blog.slug}`} className="card-read-more">
           Read Article →

--- a/src/pages/blogs/index.tsx
+++ b/src/pages/blogs/index.tsx
@@ -340,7 +340,9 @@ const BlogCard = ({ blog }: { blog: (typeof blogs)[number] }) => {
             </div>
           </div>
           <span className="card-read-time">
-  🕒 {Math.max(1, Math.ceil((item.content || "").split(" ").length / 200))} min read
+  <span className="card-read-time">
+  🕒 {Math.max(1, Math.ceil((blog.content || "").split(" ").length / 200))} min read
+</span>
 </span>
         </div>
         <Link to={`/blog/${blog.slug}`} className="card-read-more">


### PR DESCRIPTION
Closes #1544

## Changes
- Fixed read time calculation in `src/pages/blogs/index.tsx` to use actual word count
- Fixed `src/components/blogCarousel/blogCard.tsx` to use `blog` instead of `item` in read time calculation

## Test plan
- Open any blog card and verify read time displays correctly