### PR TITLE
fix alignment to centre on homepage in the FAQs section

### DIFF
--- a/src/components/faqs/faqs.tsx
+++ b/src/components/faqs/faqs.tsx
@@ -86,6 +86,7 @@ const FAQs: React.FC = () => {
             <p
               className={`mx-auto mt-3 max-w-3xl text-base ${isDark ? "text-gray-400" : "text-gray-600"
                 }`}
+              style={{ textAlign: "center" }}
             >
               Find answers to the most common questions about recode hive.
             </p>
@@ -116,8 +117,8 @@ const FAQs: React.FC = () => {
                   >
                     <button
                       className={`accordion-toggle group flex w-full cursor-pointer items-center justify-between gap-4 p-4 text-left text-base font-semibold transition-all duration-300 focus:outline-none md:p-5 ${isDark
-                          ? "text-gray-100 hover:text-indigo-300"
-                          : "text-gray-800 hover:text-indigo-700"
+                        ? "text-gray-100 hover:text-indigo-300"
+                        : "text-gray-800 hover:text-indigo-700"
                         }`}
                       style={{
                         background: isDark
@@ -205,8 +206,8 @@ const FAQs: React.FC = () => {
                   >
                     <button
                       className={`accordion-toggle group flex w-full cursor-pointer items-center justify-between gap-4 p-4 text-left text-base font-semibold transition-all duration-300 focus:outline-none md:p-5 ${isDark
-                          ? "text-gray-100 hover:text-indigo-300"
-                          : "text-gray-800 hover:text-indigo-700"
+                        ? "text-gray-100 hover:text-indigo-300"
+                        : "text-gray-800 hover:text-indigo-700"
                         }`}
                       style={{
                         background: isDark

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -398,12 +398,54 @@ html[data-theme="dark"] .menu__link--active::after {
   white-space: nowrap;
 }
 
+/* Center FAQ subtitle under the main FAQ heading */
+
+.mb-10.text-center {
+  display: flex !important;
+  flex-direction: column !important;
+  align-items: center !important;
+  text-align: center !important;
+}
+
+/* Ensure the FAQ section container is centered and uses the intended max-width */
+.relative .mx-auto.max-w-6xl {
+  margin-left: auto !important;
+  margin-right: auto !important;
+  width: 100% !important;
+  max-width: 1100px !important;
+  padding-left: 1rem !important;
+  padding-right: 1rem !important;
+}
+
+.mb-10.text-center {
+  justify-content: center !important;
+}
+
+.mb-10.text-center>p,
+.mb-10.text-center p.mx-auto {
+  margin-left: auto !important;
+  margin-right: auto !important;
+}
+
 .navbar__items {
+
   display: flex;
   align-items: center;
   gap: 0.3rem !important;
   margin: 0 !important;
   padding: 0 !important;
+}
+
+.mb-10.text-center>p.mx-auto.max-w-3xl {
+  align-self: center !important;
+  text-align: center !important;
+  width: 100% !important;
+  max-width: 900px !important;
+  box-sizing: border-box !important;
+  padding-left: 1rem !important;
+  padding-right: 1rem !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
 }
 
 /* ======== SECTION 7 : Adjust individual navbar items ==========*/


### PR DESCRIPTION
## Description

Centered the FAQ subtitle under the “Looking for answers?” heading and added safeguards so it stays centered across breakpoints.
Fixes #1703 

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made

Modified: [custom.css] — added and adjusted CSS rules to center the FAQ header and subtitle, specifically:

Made .mb-10.text-center a centered flex column (align-items and justify-content).
Added a rule for the main container .relative .mx-auto.max-w-6xl to ensure appropriate max-width and centered margins.
Added/updated selector .mb-10.text-center > p.mx-auto.max-w-3xl to force the subtitle to use full header width, set text-align: center, width: 100%, max-width, padding, and remove conflicting margins.

Removed an invalid nested CSS block and replaced it with valid top-level rules.

Modified: [faqs.tsx]— added an inline style [style={{ textAlign: "center" }}] on the subtitle [<p>] as a defensive measure to override any other CSS that might prevent centering.

<img width="1190" height="643" alt="Screenshot 2026-05-25 205908" src="https://github.com/user-attachments/assets/ee304d42-573e-4ad6-aee4-86a4575e1c84" />


## Dependencies

- None

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers and devices
- [x] My changes do not generate new console warnings or errors .
- [x] I ran `npm run build` and attached screenshot(s) in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.
