### PR TITLE
Change the color to white on blogs

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -358,6 +358,72 @@ html[data-theme="dark"] .menu__link--active::after {
   color: #60a5fa;
 }
 
+/* Ensure blog and markdown content is readable in dark mode */
+html[data-theme="dark"] .blog .markdown,
+html[data-theme="dark"] .blog-post .markdown,
+html[data-theme="dark"] .markdown,
+html[data-theme="dark"] article,
+html[data-theme="dark"] .post,
+html[data-theme="dark"] .content,
+html[data-theme="dark"] .blog .content {
+  color: #ffffff !important;
+}
+
+/* Make headings and list text white as well */
+html[data-theme="dark"] .markdown h1,
+html[data-theme="dark"] .markdown h2,
+html[data-theme="dark"] .markdown h3,
+html[data-theme="dark"] .markdown h4,
+html[data-theme="dark"] .markdown h5,
+html[data-theme="dark"] .markdown h6,
+html[data-theme="dark"] .blog .markdown h1,
+html[data-theme="dark"] .blog .markdown h2 {
+  color: #ffffff !important;
+}
+
+/* Links in blog content should be clearly visible in dark mode */
+/* Links in blog content should be clearly visible in dark mode.
+   Narrow targeting to anchors within article markdown paragraphs so
+   tag-pill components and other tagged elements keep their original colors. */
+html[data-theme="dark"] article .markdown p a,
+html[data-theme="dark"] article p a,
+html[data-theme="dark"] .blog-post .markdown p a {
+  color: #93c5fd !important;
+}
+
+/* Force article/blog post prose to white in dark mode without touching tag pills */
+html[data-theme="dark"] article h1,
+html[data-theme="dark"] article h2,
+html[data-theme="dark"] article h3,
+html[data-theme="dark"] article h4,
+html[data-theme="dark"] article h5,
+html[data-theme="dark"] article h6,
+html[data-theme="dark"] article p,
+html[data-theme="dark"] article li,
+html[data-theme="dark"] article blockquote,
+html[data-theme="dark"] article dd,
+html[data-theme="dark"] article dt,
+html[data-theme="dark"] article small,
+html[data-theme="dark"] article figcaption,
+html[data-theme="dark"] .blog-wrapper,
+html[data-theme="dark"] .blog-post-page,
+html[data-theme="dark"] .plugin-blog,
+html[data-theme="dark"] .container p,
+html[data-theme="dark"] .col--7 p,
+html[data-theme="dark"] .row p {
+  color: #ffffff !important;
+  -webkit-text-fill-color: #ffffff !important;
+}
+
+/* Also enforce for lists and blockquotes inside posts */
+html[data-theme="dark"] article li,
+html[data-theme="dark"] article ul,
+html[data-theme="dark"] article ol,
+html[data-theme="dark"] article blockquote {
+  color: #ffffff !important;
+  -webkit-text-fill-color: #ffffff !important;
+}
+
 /* Navbar styling and alignment */
 .navbar,
 .navbar__inner,


### PR DESCRIPTION
## Description

The color of the text of the content in blogs is not that readable making it difficult to read , also provides low contrast.
Fixes #1697 

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made

Dark-mode blog content was overridden to use white text for headings and body copy in [custom.css:389], while keeping tag-pill colors unchanged.

<img width="1037" height="684" alt="Screenshot 2026-05-25 213255" src="https://github.com/user-attachments/assets/9dd98999-d65f-4dc2-a111-142a276eaa65" />


## Dependencies

- None

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers and devices
- [x] My changes do not generate new console warnings or errors .
- [x] I ran `npm run build` and attached screenshot(s) in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.
