### PR TITLE
fix: move toast notification to bottom-right and update slide animation (#1716)

### DIFF
--- a/src/theme/Root.module.css
+++ b/src/theme/Root.module.css
@@ -1,7 +1,7 @@
 /* Base styles for the toast container */
 .toastContainer {
   position: fixed;
-  bottom: 20px;
+  top: 30px;
   right: 24px;
   border: 1px solid oklch(0.69 0 0);
   border-radius: 8px; /* Docusaurus --radius var is often 8px */

--- a/src/theme/Root.module.css
+++ b/src/theme/Root.module.css
@@ -1,7 +1,7 @@
 /* Base styles for the toast container */
 .toastContainer {
   position: fixed;
-  top: 30px;
+  top: 40px;
   right: 24px;
   border: 1px solid oklch(0.69 0 0);
   border-radius: 8px; /* Docusaurus --radius var is often 8px */

--- a/src/theme/Root.module.css
+++ b/src/theme/Root.module.css
@@ -1,7 +1,7 @@
 /* Base styles for the toast container */
 .toastContainer {
   position: fixed;
-  top: 20px;
+  bottom: 20px;
   right: 24px;
   border: 1px solid oklch(0.69 0 0);
   border-radius: 8px; /* Docusaurus --radius var is often 8px */
@@ -94,7 +94,7 @@
 @keyframes slideDownFadeOut {
   0% {
     opacity: 0;
-    transform: translateY(-10px) scale(0.95);
+    transform: translateY(10px) scale(0.95);
   }
   10%,
   90% {
@@ -103,6 +103,6 @@
   }
   100% {
     opacity: 0;
-    transform: translateY(-10px) scale(0.95);
+    transform: translateY(10px) scale(0.95);
   }
 }


### PR DESCRIPTION
## Summary
Fixes #1716

The toast notification ("Check out our latest leaderboard!") was appearing at the top-right of the screen, overlapping the navbar and cluttering the top UI. This fix moves it to the bottom-right for a cleaner, less intrusive experience.

## Changes Made
- `src/theme/Root.module.css` — changed `top: 20px` to `bottom: 20px` in `.toastContainer`
- `src/theme/Root.module.css` — updated `slideDownFadeOut` keyframes to slide up from bottom (`translateY(10px)`) instead of sliding down from top (`translateY(-10px)`)

## Before
Toast appeared at top-right, overlapping the navigation bar.

## After
Toast appears at bottom-right with a slide-up animation, keeping the top UI clean.

---
Contributing under GSSoC'26