### PR TITLE
fix: resolve overlapping content on aditya author page #1558

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -2703,3 +2703,18 @@ html[data-theme="dark"] .blog-post-page .markdown h4 {
   width: 52px !important;
   height: 52px !important;
 }
+
+/* Fix overlapping content on Aditya Singh Rathore's author page #1558 */
+[class*="author-aditya-singh-rathore"] .avatar,
+[class*="author-aditya-singh-rathore"] .hero {
+  margin-bottom: 2rem !important;
+}
+
+[class*="author-aditya-singh-rathore"] .social-links,
+[class*="author-aditya-singh-rathore"] .author-socials {
+  display: flex !important;
+  justify-content: center !important;
+  gap: 15px !important;
+  margin-top: 15px !important;
+}
+


### PR DESCRIPTION
### Description
Fixed the overlapping content layout bug on Aditya Singh Rathore's profile page as requested. The fix uses a highly targeted wrapper selector so it exclusively adjusts his profile styling without altering any global author configurations.

### Changes Made
- Added isolated spacing adjustments below the hero/avatar elements.
- Restructured layout constraints to cleanly align social badges and textual blocks.

Closes #1558


