### PR TITLE
fix: replace author handle with full name on blogs and individual blo…

### DIFF
--- a/src/pages/blogs/index.tsx
+++ b/src/pages/blogs/index.tsx
@@ -341,7 +341,7 @@ const BlogCard = ({ blog }: { blog: (typeof blogs)[number] }) => {
                         rel="noopener noreferrer"
                         title={author.name}
                       >
-                        @{author.id || author.name.toLowerCase().replace(/\s+/g, "")}
+                        {author.name}
                       </Link>
                     </React.Fragment>
                   ))}

--- a/src/theme/BlogPostItem/Header/index.tsx
+++ b/src/theme/BlogPostItem/Header/index.tsx
@@ -78,10 +78,10 @@ export default function BlogPostItemHeaderWrapper(props: Props): JSX.Element {
 
   const blogDate = metadata.date
     ? new Intl.DateTimeFormat(siteConfig.i18n?.defaultLocale || "en-US", {
-        year: "numeric",
-        month: "short",
-        day: "numeric",
-      }).format(new Date(metadata.date))
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    }).format(new Date(metadata.date))
     : undefined;
 
   const tags = (metadata.tags ?? [])
@@ -121,10 +121,11 @@ export default function BlogPostItemHeaderWrapper(props: Props): JSX.Element {
                 ))}
               </div>
               {/* Handles after the stack (only authors with a handle) */}
+              {/* Full name after the stack */}
               {authors
-                .filter((author) => author.handle)
+                .filter((author) => author.name || author.handle)
                 .map((author, idx) => (
-                  <React.Fragment key={author.handle}>
+                  <React.Fragment key={author.handle ?? author.name}>
                     {idx > 0 && (
                       <span className={styles.authorSep} aria-hidden="true">
                         ,
@@ -137,10 +138,10 @@ export default function BlogPostItemHeaderWrapper(props: Props): JSX.Element {
                         target="_blank"
                         rel="noopener noreferrer"
                       >
-                        {author.handle}
+                        {author.name || author.handle}
                       </Link>
                     ) : (
-                      <span className={styles.handle}>{author.handle}</span>
+                      <span className={styles.handle}>{author.name || author.handle}</span>
                     )}
                   </React.Fragment>
                 ))}


### PR DESCRIPTION
Fixes #1730
What was changed:

Replaced @handle style (e.g. @sanjay-kv) with the author's full name (e.g. Sanjay Viswanthan)

Files modified:

src/pages/blogs/index.tsx — fixed author name on blog listing cards
src/theme/BlogPostItem/Header/index.tsx — fixed author name on individual blog posts

screenshot :

<img width="1920" height="1020" alt="Screenshot 2026-05-26 171216" src="https://github.com/user-attachments/assets/63838417-2182-4b77-9c05-ca89e0bf6a49" />
<img width="1920" height="1020" alt="Screenshot 2026-05-26 171226" src="https://github.com/user-attachments/assets/165ef606-fde8-4a1b-8ca7-c424d197e9fd" />
