### PR TITLE
fix: improve author card visibility in dark mode

### DIFF
--- a/src/theme/BlogPostItem/Footer/styles.module.css
+++ b/src/theme/BlogPostItem/Footer/styles.module.css
@@ -252,3 +252,36 @@
     justify-content: center;
   }
 }
+
+/* Dark mode fixes for author card visibility */
+[data-theme='dark'] .authorCard {
+  background: #1e1e1e;
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+[data-theme='dark'] .authorName {
+  color: #f1f5f9;
+}
+
+[data-theme='dark'] .authorMeta {
+  color: #94a3b8;
+}
+
+[data-theme='dark'] .authorSummary {
+  color: #cbd5e1;
+}
+
+[data-theme='dark'] .authorBadge {
+  background: rgba(99, 102, 241, 0.15);
+  color: #a5b4fc;
+}
+
+[data-theme='dark'] .githubButton {
+  background: #2a2a2a;
+  border-color: rgba(255, 255, 255, 0.12);
+  color: #f1f5f9;
+}
+
+[data-theme='dark'] .githubButton:hover {
+  background: #333333;
+}


### PR DESCRIPTION
## Description

Added dark mode CSS overrides for the author card component to fix low contrast/visibility issues where text was barely readable in dark mode.
Fixes #1698 

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [ yes] Bug fix (non-breaking change that fixes an issue)
- [ yes] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made

Added [data-theme='dark'] CSS overrides in src/theme/BlogPostItem/Footer/styles.module.css
Author card background set to #1e1e1e in dark mode for proper contrast
Author name color set to #f1f5f9 for high visibility
Author meta text set to #94a3b8 for readable secondary contrast
Author summary set to #cbd5e1 for legible body text
Author badge styled with indigo tint background and light text
GitHub button styled with dark background, light border and text in dark mode

## Dependencies
No new dependencies added.

## Checklist

- [yes ] My code follows the style guidelines of this project.
- [yes ] I have tested my changes across major browsers and devices
- [yes ] My changes do not generate new console warnings or errors .
- [ yes] I ran `npm run build` and attached screenshot(s) in this PR.
- [yes ] This is already assigned Issue to me, not an unassigned issue.

<img width="823" height="465" alt="Screenshot 2026-05-27 at 12 17 34 PM" src="https://github.com/user-attachments/assets/b6b8c0ac-6e00-4822-b469-c09e16bb7299" />
<img width="1422" height="810" alt="Screenshot 2026-05-27 at 12 10 49 PM" src="https://github.com/user-attachments/assets/15211525-9657-4c8e-8ed2-f8b2f9a91060" />
