### PR TITLE
 Fix: Homepage Carousel Auto-Rotation Issue

### DIFF
--- a/src/components/blogCarousel/blogCarousel.tsx
+++ b/src/components/blogCarousel/blogCarousel.tsx
@@ -27,9 +27,15 @@ export function BlogCarousel() {
     setCount(api.scrollSnapList().length);
     setCurrent(api.selectedScrollSnap() + 1);
 
-    api.on("select", () => {
+    const onSelect = () => {
       setCurrent(api.selectedScrollSnap() + 1);
-    });
+    };
+
+    api.on("select", onSelect);
+
+    return () => {
+      api.off("select", onSelect);
+    };
   }, [api]);
 
   return (
@@ -62,8 +68,9 @@ export function BlogCarousel() {
         }}
         plugins={[
           Autoplay({
-            delay: 4000,
-            stopOnInteraction: true,
+            delay: 5000,
+            stopOnInteraction: false,
+            stopOnMouseEnter: true,
           }),
         ]}
       >


### PR DESCRIPTION
## Description

This PR fixes the carousel component on the homepage that was stopping after displaying the first image instead of continuously rotating through all promotional banners.

The carousel is now configured to:
- Automatically rotate every 5 seconds with smooth transitions
- Continuously loop back to the first slide after reaching the last one
- Work seamlessly on both desktop and mobile browsers
- Pause on mouse hover for better user experience

Fixes #1769 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)

## Changes Made

### Modified Files:
- **src/components/blogCarousel/blogCarousel.tsx**

### Key Changes:
1. **Fixed event listener cleanup** - Added proper `api.off("select", onSelect)` in useEffect cleanup to prevent memory leaks
2. **Enabled continuous autoplay** - Changed `stopOnInteraction` from `true` to `false` so carousel continues rotating even after user clicks
3. **Improved user experience** - Added `stopOnMouseEnter: true` so carousel pauses when hovering, then resumes automatically
4. **Updated rotation timing** - Changed delay from 4000ms to 5000ms for better visibility of each slide

## Dependencies

- No new dependencies added
- Uses existing: `embla-carousel-react@^8.6.0` and `embla-carousel-autoplay@^8.6.0`
- No version updates required

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have tested my changes across major browsers and devices
- [ ] My changes do not generate new console warnings or errors .
- [ ] I ran `npm run build` and attached screenshot(s) in this PR.
- [ ] This is already assigned Issue to me, not an unassigned issue.
