### PR TITLE
Improve filter visibility and add clear filters option

### DIFF
--- a/src/pages/showcase/_components/ShowcaseTagSelect/styles.module.css
+++ b/src/pages/showcase/_components/ShowcaseTagSelect/styles.module.css
@@ -10,7 +10,7 @@
   box-shadow: 0 0 2px 1px var(--ifm-color-secondary-darkest);
 }
 
-input[type="checkbox"] + .checkboxLabel {
+input[type="checkbox"]+.checkboxLabel {
   display: flex;
   align-items: center;
   cursor: pointer;
@@ -22,30 +22,38 @@ input[type="checkbox"] + .checkboxLabel {
   border: 2px solid var(--ifm-color-secondary-darkest);
 }
 
-input:focus-visible + .checkboxLabel {
+input:focus-visible+.checkboxLabel {
   outline: 2px solid currentColor;
 }
 
-input:checked + .checkboxLabel {
-  opacity: 0.9;
-  background-color: var(--site-color-checkbox-checked-bg);
+input:checked+.checkboxLabel {
+  opacity: 1;
+  background-color: var(--ifm-color-primary);
+  color: white;
   border: 2px solid var(--ifm-color-primary-darkest);
+  font-weight: 600;
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.2);
 }
 
-input:checked + .checkboxLabel:hover {
+[data-theme="dark"] input:checked+.checkboxLabel {
+  color: white;
+}
+
+input:checked+.checkboxLabel:hover {
   opacity: 0.75;
   box-shadow: 0 0 2px 1px var(--ifm-color-primary-dark);
 }
-input[type="checkbox"] + .checkboxLabel {
+
+input[type="checkbox"]+.checkboxLabel {
   color: var(--ifm-color-content);
 }
 
-[data-theme="dark"] input[type="checkbox"] + .checkboxLabel {
+[data-theme="dark"] input[type="checkbox"]+.checkboxLabel {
   color: #ffffff;
   border-color: #555555;
 }
 
-[data-theme="light"] input[type="checkbox"] + .checkboxLabel {
+[data-theme="light"] input[type="checkbox"]+.checkboxLabel {
   color: #000000;
   border-color: var(--ifm-color-secondary-darkest);
 }

--- a/src/pages/showcase/index.tsx
+++ b/src/pages/showcase/index.tsx
@@ -188,8 +188,25 @@ function useSiteCountPlural() {
 function ShowcaseFilters({ isDark = false }: { isDark?: boolean }) {
   const filteredUsers = useFilteredUsers();
   const siteCountPlural = useSiteCountPlural();
+  const history = useHistory();
+  const location = useLocation();
+
+  const clearFilters = () => {
+    const params = new URLSearchParams(location.search);
+
+    params.delete("tags");
+    params.delete("name");
+    params.delete("operator");
+
+    history.push({
+      ...location,
+      search: params.toString(),
+      state: prepareUserState(),
+    });
+  };
+
   return (
-       <section className="margin-top--l margin-bottom--lg container">
+    <section className="margin-top--l margin-bottom--lg container">
       <div className={clsx("margin-bottom--sm", styles.filterCheckbox)}>
         <div>
           <motion.h2
@@ -219,7 +236,16 @@ function ShowcaseFilters({ isDark = false }: { isDark?: boolean }) {
             <span>{siteCountPlural(filteredUsers.length)}</span>
           </motion.div>
         </div>
-        <ShowcaseFilterToggle />
+        <div style={{ display: "flex", gap: "10px", alignItems: "center" }}>
+          <ShowcaseFilterToggle />
+
+          <button
+            className={styles.clearFilterButton}
+            onClick={clearFilters}
+          >
+            Clear Filters
+          </button>
+        </div>
       </div>
       <motion.ul
         initial={{ opacity: 0 }}

--- a/src/pages/showcase/styles.module.css
+++ b/src/pages/showcase/styles.module.css
@@ -8,13 +8,13 @@
   align-items: center;
 }
 
-.filterCheckbox > div:first-child {
+.filterCheckbox>div:first-child {
   display: flex;
   flex: 1 1 auto;
   align-items: center;
 }
 
-.filterCheckbox > div > * {
+.filterCheckbox>div>* {
   margin-bottom: 0;
   margin-right: 8px;
 }
@@ -81,11 +81,11 @@
   align-items: center;
 }
 
-.showcaseFavoriteHeader > h2 {
+.showcaseFavoriteHeader>h2 {
   margin-bottom: 0;
 }
 
-.showcaseFavoriteHeader > svg {
+.showcaseFavoriteHeader>svg {
   width: 30px;
   height: 30px;
 }
@@ -105,15 +105,14 @@
 }
 
 .TitleText {
-  background: linear-gradient(
-    90deg,
-    rgb(152 0 255) 0%,
-    rgb(246 41 41) 50%,
-    rgb(255 169 8) 100%
-  );
+  background: linear-gradient(90deg,
+      rgb(152 0 255) 0%,
+      rgb(246 41 41) 50%,
+      rgb(255 169 8) 100%);
   background-clip: text;
   -webkit-text-fill-color: transparent;
 }
+
 [data-theme="dark"] .filterCheckbox {
   background-color: transparent !important;
   color: #ffffff !important;
@@ -135,6 +134,7 @@
 [data-theme="dark"] .showcaseFavorite {
   background-color: #1a1a1a !important;
 }
+
 [data-theme="dark"] .filterCheckbox {
   background-color: transparent !important;
   color: #ffffff !important;
@@ -155,4 +155,31 @@
 
 [data-theme="dark"] .showcaseFavorite {
   background-color: #1a1a1a !important;
+}
+
+
+.clearFilterButton {
+  padding: 4px 10px;
+  font-size: 12px;
+  border-radius: 4px;
+  border: 2px solid var(--ifm-color-primary);
+  background: transparent;
+  color: var(--ifm-color-primary);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.clearFilterButton:hover {
+  background: var(--ifm-color-primary);
+  color: white;
+}
+
+[data-theme="dark"] .clearFilterButton {
+  color: var(--ifm-color-primary-lighter);
+  border-color: var(--ifm-color-primary-lighter);
+}
+
+[data-theme="dark"] .clearFilterButton:hover {
+  background: var(--ifm-color-primary);
+  color: #fff;
 }


### PR DESCRIPTION
## Description

Improved the filter user experience on the Showcase page.

## Changes Made

* Enhanced the visual appearance of selected filter tags to make active filters easier to identify.
* Added a Clear Filters button to quickly reset applied filters.
* Added styling for the new Clear Filters button while maintaining consistency with the existing UI.

## Testing

* Verified filter selection and deselection.
* Verified Clear Filters functionality.
* Verified AND/OR toggle behavior remains unchanged.
* Tested in dark mode.

## Screenshots

<img width="1919" height="969" alt="Screenshot 2026-05-29 112859" src="https://github.com/user-attachments/assets/64dd95bd-666b-44f7-bf75-e9a067e1472c" />
<img width="1918" height="924" alt="Screenshot 2026-05-29 112913" src="https://github.com/user-attachments/assets/d99f5cb5-d9f4-4275-8901-ca69329477d6" />

Closes #1774 
