### PR TITLE
markdown links build

### DIFF
--- a/blog/google-icon-update/index.md
+++ b/blog/google-icon-update/index.md
@@ -38,6 +38,7 @@ import TabItem from '@theme/TabItem';
 import ZoomImage from '@site/src/components/ZoomImage';
 import imgGsuite from './assets/03-google-old-gsuite-logo.png';
 import imgWorkspace from './assets/06-googleworkspace-new-logo.png';
+import imgXPost from './assets/10-x-post.png';
 
 <!-- truncate -->
 
@@ -141,11 +142,11 @@ Reactions are split, which is predictable and honestly fair.
 The people who are happy are mostly the ones who experienced the confusion problem most acutely. People who live in browser tabs with ten Google services pinned simultaneously. People whose phone home screens are a wall of identical four-color squares. For this group, the new icons are a long-overdue fix and the response is straightforward relief.
 Looking at the new icons directly, here is what stands out:
 
-  <BrowserWindow url="https://x.com/Gautamk104/status/2057843133392842780?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E2057843133392842780%7Ctwgr%5E3dbaf20e8e4f9f64fd6032e85f7ed7c1e1b5fe0f%7Ctwcon%5Es1_c10&ref_url=https%3A%2F%2Fpublish.twitter.com%2F%3Furl%3Dhttps%3A%2F%2Ftwitter.com%2FGautamk104%2Fstatus%2F2057843133392842780" bodyStyle={{padding: 0}}>
-    <a href="https://x.com/Gautamk104/status/2057843133392842780?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E2057843133392842780%7Ctwgr%5E3dbaf20e8e4f9f64fd6032e85f7ed7c1e1b5fe0f%7Ctwcon%5Es1_c10&ref_url=https%3A%2F%2Fpublish.twitter.com%2F%3Furl%3Dhttps%3A%2F%2Ftwitter.com%2FGautamk104%2Fstatus%2F2057843133392842780" target="_blank" rel="noreferrer noopener">
-      <img src="./assets/10-x-post.png" alt="Github" />
+  <BrowserWindow url="https://x.com/Gautamk104/status/2057843133392842780?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E2057843133392842780%7Ctwgr%5E3dbaf20e8e4f9f64fd6032e85f7ed7c1e1b5fe0f%7Ctwcon%5Es1_c10&ref_url=https%3A%2F%2Fpublish.twitter.com%2F%3Furl%3Dhttps%3A%2F%2Ftwitter.com%2FGautamk104%2Fstatus%2F2057843133392842780" bodyStyle={{padding: 0}}>    
+    <a href="https://x.com/Gautamk104/status/2057843133392842780?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E2057843133392842780%7Ctwgr%5E3dbaf20e8e4f9f64fd6032e85f7ed7c1e1b5fe0f%7Ctwcon%5Es1_c10&ref_url=https%3A%2F%2Fpublish.twitter.com%2F%3Furl%3Dhttps%3A%2F%2Ftwitter.com%2FGautamk104%2Fstatus%2F2057843133392842780">
+      <img src={imgXPost} alt="X post about the Google Workspace icon update" />
     </a>
-  </BrowserWindow>
+    </BrowserWindow>
 
 
 My honest take: some of the new icons are significantly better, Drive and Calendar especially. A few are sideways moves rather than improvements. Gmail's gradient version is fine but the 2020 version was not actually the confusing one, the envelope shape was always distinctive enough. The icons that most needed differentiation got it. The ones that were already recognizable got gradients they did not necessarily need.

--- a/blog/google-icon-update/index.md
+++ b/blog/google-icon-update/index.md
@@ -141,9 +141,11 @@ Reactions are split, which is predictable and honestly fair.
 The people who are happy are mostly the ones who experienced the confusion problem most acutely. People who live in browser tabs with ten Google services pinned simultaneously. People whose phone home screens are a wall of identical four-color squares. For this group, the new icons are a long-overdue fix and the response is straightforward relief.
 Looking at the new icons directly, here is what stands out:
 
-  <BrowserWindow url="https://x.com/Gautamk104/status/2057843133392842780?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E2057843133392842780%7Ctwgr%5E3dbaf20e8e4f9f64fd6032e85f7ed7c1e1b5fe0f%7Ctwcon%5Es1_c10&ref_url=https%3A%2F%2Fpublish.twitter.com%2F%3Furl%3Dhttps%3A%2F%2Ftwitter.com%2FGautamk104%2Fstatus%2F2057843133392842780" bodyStyle={{padding: 0}}>    
-     [![Github](./assets/10-x-post.png)](https://x.com/Gautamk104/status/2057843133392842780?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E2057843133392842780%7Ctwgr%5E3dbaf20e8e4f9f64fd6032e85f7ed7c1e1b5fe0f%7Ctwcon%5Es1_c10&ref_url=https%3A%2F%2Fpublish.twitter.com%2F%3Furl%3Dhttps%3A%2F%2Ftwitter.com%2FGautamk104%2Fstatus%2F2057843133392842780)
-    </BrowserWindow>
+  <BrowserWindow url="https://x.com/Gautamk104/status/2057843133392842780?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E2057843133392842780%7Ctwgr%5E3dbaf20e8e4f9f64fd6032e85f7ed7c1e1b5fe0f%7Ctwcon%5Es1_c10&ref_url=https%3A%2F%2Fpublish.twitter.com%2F%3Furl%3Dhttps%3A%2F%2Ftwitter.com%2FGautamk104%2Fstatus%2F2057843133392842780" bodyStyle={{padding: 0}}>
+    <a href="https://x.com/Gautamk104/status/2057843133392842780?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E2057843133392842780%7Ctwgr%5E3dbaf20e8e4f9f64fd6032e85f7ed7c1e1b5fe0f%7Ctwcon%5Es1_c10&ref_url=https%3A%2F%2Fpublish.twitter.com%2F%3Furl%3Dhttps%3A%2F%2Ftwitter.com%2FGautamk104%2Fstatus%2F2057843133392842780" target="_blank" rel="noreferrer noopener">
+      <img src="./assets/10-x-post.png" alt="Github" />
+    </a>
+  </BrowserWindow>
 
 
 My honest take: some of the new icons are significantly better, Drive and Calendar especially. A few are sideways moves rather than improvements. Gmail's gradient version is fine but the 2020 version was not actually the confusing one, the envelope shape was always distinctive enough. The icons that most needed differentiation got it. The ones that were already recognizable got gradients they did not necessarily need.


### PR DESCRIPTION
## Description

Fixing the nested markdown link inside the BrowserWindow block to use explicit JSX and avoid invalid markdown parsing.
Verifying the markdown file now contains no empty markdown link tokens and the replacement is correct.
Replaced the nested markdown link inside the [<BrowserWindow>] block with explicit JSX:
<a href="...">
<img src="..." alt="Github" />
This removes the invalid markdown link construct and avoids the empty-link warning.

Fixes #1776 

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Corrected the invalid nested markdown link in `blog/google-icon-update/index.md` by replacing the nested markdown image link with explicit `<a>` and `<img>` tags.

## Dependencies

- No new dependencies added.
- No version updates required.

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have tested my changes across major browsers and devices
- [ ] My changes do not generate new console warnings or errors .
- [ ] I ran `npm run build` and attached screenshot(s) in this PR.
- [ ] This is already assigned Issue to me, not an unassigned issue.
