### PR TITLE
feat: add "/" keyboard shortcut to focus search

### DIFF
--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -7,6 +7,61 @@ import styles from "./Root.module.css"; // Import the CSS module
 import { useLocation } from "@docusaurus/router";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 
+function isEditableEventTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) {
+    return false;
+  }
+
+  if (target.isContentEditable) {
+    return true;
+  }
+
+  const tagName = target.tagName.toLowerCase();
+  if (tagName === "textarea" || tagName === "select") {
+    return true;
+  }
+
+  if (target instanceof HTMLInputElement) {
+    const editableTypes = new Set([
+      "text",
+      "search",
+      "url",
+      "tel",
+      "email",
+      "password",
+      "number",
+      "date",
+      "datetime-local",
+      "month",
+      "time",
+      "week",
+    ]);
+    return !target.readOnly && !target.disabled && editableTypes.has(target.type);
+  }
+
+  return target.matches(
+    "[contenteditable='true'], [contenteditable=''], [contenteditable='plaintext-only']",
+  );
+}
+
+function focusSearchInput(): boolean {
+  const navbarSearch = document.querySelector<HTMLInputElement>(
+    "#algolia-sitesearch-navbar input",
+  );
+  if (navbarSearch) {
+    navbarSearch.focus({ preventScroll: true });
+    return true;
+  }
+
+  const blogSearch = document.querySelector<HTMLInputElement>(".blog-search-input");
+  if (blogSearch) {
+    blogSearch.focus({ preventScroll: true });
+    return true;
+  }
+
+  return false;
+}
+
 // A simple Trophy SVG icon component
 function TrophyIcon() {
   return (
@@ -141,6 +196,33 @@ export default function Root({ children }: { children: React.ReactNode }) {
 
     return () => {
       observer.disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
+    function handleGlobalSearchShortcut(event: KeyboardEvent) {
+      if (
+        event.key !== "/" ||
+        event.defaultPrevented ||
+        event.metaKey ||
+        event.altKey ||
+        event.ctrlKey
+      ) {
+        return;
+      }
+
+      if (isEditableEventTarget(event.target)) {
+        return;
+      }
+
+      if (focusSearchInput()) {
+        event.preventDefault();
+      }
+    }
+
+    document.addEventListener("keydown", handleGlobalSearchShortcut);
+    return () => {
+      document.removeEventListener("keydown", handleGlobalSearchShortcut);
     };
   }, []);
 


### PR DESCRIPTION
## Description

Adds a global `/` keyboard shortcut to quickly focus the website search bar across documentation and blog pages. This improves navigation speed and accessibility by allowing users to start searching without manually clicking the search input.

Fixes #1800 

## Type of Change

* [x] New feature (e.g., new page, component, or functionality)
* [ ] Bug fix (non-breaking change that fixes an issue)
* [x] UI/UX improvement (design, layout, or styling updates)
* [ ] Performance optimization (e.g., code splitting, caching)
* [ ] Documentation update (README, contribution guidelines, etc.)
* [ ] Other (please specify):

## Changes Made

* Added a global `keydown` listener to handle the `/` keyboard shortcut.
* Focuses the search input when `/` is pressed anywhere on the site.
* Supports both documentation and blog search inputs.
* Prevents the shortcut from triggering while the user is typing inside:

  * `input`
  * `textarea`
  * `select`
  * `contenteditable` elements
* Prevents the `/` character from being inserted when the shortcut activates.
* Added proper cleanup for event listeners to avoid duplicate handlers and memory leaks.
* Preserved all existing search functionality and keyboard interactions.

## Dependencies

* No new dependencies added.
* No version updates required.
* No additional configuration changes required.

## Checklist

* [x] My code follows the style guidelines of this project.
* [x] I have tested my changes across major browsers and devices.
* [x] My changes do not generate new console warnings or errors.
* [ ] I ran `npm run build` and attached screenshot(s) in this PR.
* [x] This is already assigned Issue to me, not an unassigned issue.
