### PR TITLE
fix text wrapping and inconsistent icons in doc

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -969,7 +969,7 @@ body {
 .dropdown-content .grid {
   width: 100% !important;
   /* Comfortable space between the label column and icons column */
-  column-gap: 1rem !important;
+  column-gap: 0.6rem !important;
   /* Subtle vertical space per row */
   padding: 0.35rem 0 !important;
 }
@@ -1033,6 +1033,60 @@ body {
 .dropdown-content .col-span-1,
 .dropdown-content .col-span-2 {
   color: var(--ifm-font-color-base);
+}
+
+/* Prevent labels in the left column of navbar dropdowns from wrapping */
+.dropdown-content .border-r.col-span-1,
+.dropdown__menu .border-r.col-span-1,
+.dropdown-content .col-span-1>a,
+.dropdown__menu .col-span-1>a {
+  white-space: nowrap !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+}
+
+/* Stronger layout rules to keep labels and icons aligned across deployments */
+.dropdown__menu .grid>.border-r.col-span-1,
+.dropdown-content .grid>.border-r.col-span-1 {
+  display: flex !important;
+  align-items: center !important;
+  justify-content: flex-start !important;
+  flex: 0 0 auto !important;
+  min-width: auto !important;
+  /* allow label to size to content */
+  padding-right: 0.4rem !important;
+}
+
+/* Make the label itself use a single line and center vertically */
+.dropdown__menu .grid>.border-r.col-span-1 a,
+.dropdown-content .grid>.border-r.col-span-1 a {
+  display: inline-block !important;
+  white-space: nowrap !important;
+  line-height: 1 !important;
+}
+
+/* Ensure icon groups are vertically centered and consistent */
+.dropdown__menu .grid .nav__icons,
+.dropdown-content .grid .nav__icons {
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  gap: 0.6rem !important;
+}
+
+.dropdown__menu .grid .nav__icons img,
+.dropdown-content .grid .nav__icons img {
+  display: block !important;
+  margin: 0 !important;
+}
+
+/* Fallback for very narrow viewports: reduce min-width slightly */
+@media (max-width: 480px) {
+
+  .dropdown__menu .grid>.border-r.col-span-1,
+  .dropdown-content .grid>.border-r.col-span-1 {
+    min-width: 72px !important;
+  }
 }
 
 .dropdown-content a:hover {


### PR DESCRIPTION
## Description

The current Docs Dropdown labels (left column: "Tutorials", "Courses") were wrapping into two lines and icon were misaligned creating visual inconsistency .
Fixes #1758

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made

- Prevented left-column labels from wrapping and added ellipsis
- Ensured dropdown icon groups are consistently centered
- Mobile fallback min-width reduced to avoid wrapping on narrow viewports.

<img width="626" height="283" alt="Screenshot 2026-05-31 131423" src="https://github.com/user-attachments/assets/1d77ab7b-e044-474e-8903-07f0781dedfe" />


## Dependencies

- None

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers and devices
- [x] My changes do not generate new console warnings or errors .
- [x] I ran `npm run build` and attached screenshot(s) in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.
