### PR TITLE
Fixed text readability in "Google icon update " Blog

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -2619,9 +2619,38 @@ html[data-theme="dark"] .blog-post-page .markdown h4 {
   font-size: inherit !important;
 }
 
-html[data-theme="dark"] .blog-post-page .markdown .admonition,
-html[data-theme="dark"] .blog-post-page .markdown .alert {
-  background: rgba(59, 130, 246, 0.1) !important;
+html[data-theme="dark"].blog-post-page .markdown .theme-admonition-info,
+html[data-theme="dark"].blog-post-page .markdown .alert--info {
+  --ifm-alert-foreground-color: #ffffff !important;
+  --ifm-alert-background-color: #0f172a !important;
+  --ifm-alert-background-color-highlight: rgba(148, 163, 184, 0.14) !important;
+  --ifm-alert-border-color: #2563eb !important;
+  --ifm-link-color: #93c5fd !important;
+  --ifm-link-hover-color: #bfdbfe !important;
+  background-color: var(--ifm-alert-background-color) !important;
+  background: var(--ifm-alert-background-color) !important;
+  border-left-color: var(--ifm-alert-border-color) !important;
+  color: #ffffff !important;
+}
+
+html[data-theme="dark"].blog-post-page .markdown .theme-admonition-info [class*="admonitionContent_"],
+html[data-theme="dark"].blog-post-page .markdown .alert--info [class*="admonitionContent_"],
+html[data-theme="dark"].blog-post-page .markdown .theme-admonition-info [class*="admonitionContent_"] p,
+html[data-theme="dark"].blog-post-page .markdown .theme-admonition-info [class*="admonitionContent_"] li,
+html[data-theme="dark"].blog-post-page .markdown .theme-admonition-info [class*="admonitionContent_"] span,
+html[data-theme="dark"].blog-post-page .markdown .theme-admonition-info [class*="admonitionContent_"] strong,
+html[data-theme="dark"].blog-post-page .markdown .theme-admonition-info [class*="admonitionContent_"] em,
+html[data-theme="dark"].blog-post-page .markdown .theme-admonition-info [class*="admonitionContent_"] code,
+html[data-theme="dark"].blog-post-page .markdown .theme-admonition-info [class*="admonitionContent_"] a,
+html[data-theme="dark"].blog-post-page .markdown .alert--info [class*="admonitionContent_"] p,
+html[data-theme="dark"].blog-post-page .markdown .alert--info [class*="admonitionContent_"] li,
+html[data-theme="dark"].blog-post-page .markdown .alert--info [class*="admonitionContent_"] span,
+html[data-theme="dark"].blog-post-page .markdown .alert--info [class*="admonitionContent_"] strong,
+html[data-theme="dark"].blog-post-page .markdown .alert--info [class*="admonitionContent_"] em,
+html[data-theme="dark"].blog-post-page .markdown .alert--info [class*="admonitionContent_"] code,
+html[data-theme="dark"].blog-post-page .markdown .alert--info [class*="admonitionContent_"] a {
+  color: #ffffff !important;
+  -webkit-text-fill-color: #ffffff !important;
 }
 
 /* Blog post page title (H1 rendered by Docusaurus header, outside .markdown) */
@@ -2888,7 +2917,7 @@ html[data-theme="dark"] .blog-post-page article header h2[itemprop="headline"] {
 .theme-doc-markdown,
 main[class*='docMainContainer_'] {
   position: relative;
-  z-index: 1 !important; 
+  z-index: 1 !important;
 }
 
 .theme-doc-markdown h1,
@@ -2903,5 +2932,5 @@ main[class*='docMainContainer_'] {
 .theme-doc-sidebar-container,
 .menu--responsive,
 div[class*='sidebarViewport_'] {
-  z-index: 9999 !important; 
+  z-index: 9999 !important;
 }


### PR DESCRIPTION
## Description

 IN the  google icon update blog , The info block lacks readability and visual consistency in the dark theme . 
ref :https://www.recodehive.com/blog/google-icon-update
Fixes #1829 

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made

 - adjusted dark-theme alert/admonition rules (info variant) to use a dark background and white foreground; ensured descendant content (p, li, a, strong, em, code) renders white.

<img width="1122" height="808" alt="Screenshot 2026-06-03 120742" src="https://github.com/user-attachments/assets/24baa200-da9d-41b0-bd76-0b1ae92254ee" />


## Dependencies

- None

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers and devices
- [x] My changes do not generate new console warnings or errors .
- [x] I ran `npm run build` and attached screenshot(s) in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.
