### PR TITLE
Revert "chore: bump lint-staged from 17.0.5 to 17.0.7"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "eslint": "^10.4.1",
         "eslint-plugin-react": "^7.37.5",
         "husky": "^9.1.7",
-        "lint-staged": "^17.0.7",
+        "lint-staged": "^17.0.5",
         "postcss": "^8.5.15",
         "prettier": "^3.8.3",
         "prettier-plugin-tailwindcss": "^0.6.14",
@@ -15934,16 +15934,16 @@
       "license": "MIT"
     },
     "node_modules/lint-staged": {
-      "version": "17.0.7",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.7.tgz",
-      "integrity": "sha512-JrSobt+tW3rH8IOMi8tDZd3foorM5yPEkLD/V2NxobgHrFfHWGee4MOLVuZeScgxftEwbHrPHIFA/ZL+nUJeuA==",
+      "version": "17.0.5",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.5.tgz",
+      "integrity": "sha512-d12yC+/e8RhBjZtaxZn71FyrgU/P5e+uAPifhCLwdosQZP/zamSdKRWDC30ocVIbzDKiFG1McHc/LUgB92GIPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "listr2": "^10.2.1",
         "picomatch": "^4.0.4",
         "string-argv": "^0.3.2",
-        "tinyexec": "^1.2.4"
+        "tinyexec": "^1.1.2"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
@@ -15955,7 +15955,7 @@
         "url": "https://opencollective.com/lint-staged"
       },
       "optionalDependencies": {
-        "yaml": "^2.9.0"
+        "yaml": "^2.8.4"
       }
     },
     "node_modules/lint-staged/node_modules/picomatch": {
@@ -24054,9 +24054,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "eslint": "^10.4.1",
     "eslint-plugin-react": "^7.37.5",
     "husky": "^9.1.7",
-    "lint-staged": "^17.0.7",
+    "lint-staged": "^17.0.5",
     "postcss": "^8.5.15",
     "prettier": "^3.8.3",
     "prettier-plugin-tailwindcss": "^0.6.14",


### PR DESCRIPTION
Reverts recodehive/recode-website#1847