### PR TITLE
Fixed  visibility issue in pagination button in leaderboard

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -2934,3 +2934,39 @@ main[class*='docMainContainer_'] {
 div[class*='sidebarViewport_'] {
   z-index: 9999 !important;
 }
+
+/* Leaderboard Pagination Button Icon Visibility Fix */
+.pagination-btn {
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  width: 40px !important;
+  height: 40px !important;
+  border: 1px solid var(--ifm-color-emphasis-300) !important;
+  background: var(--ifm-background-surface-color) !important;
+  border-radius: 8px !important;
+  cursor: pointer !important;
+  transition: all 0.2s ease !important;
+  color: var(--ifm-color-primary) !important;
+  padding: 0 !important;
+}
+
+.pagination-btn svg {
+  stroke: currentColor !important;
+  fill: none !important;
+  stroke-width: 2px !important;
+  width: 20px !important;
+  height: 20px !important;
+  display: block !important;
+}
+
+.pagination-btn:hover:not(.disabled) {
+  background: var(--ifm-color-primary) !important;
+  color: white !important;
+  border-color: var(--ifm-color-primary) !important;
+}
+
+.pagination-btn.disabled {
+  opacity: 0.4 !important;
+  cursor: not-allowed !important;
+}


### PR DESCRIPTION
## Description

The pagination in the leaderboard contains two rectangular nav buttons on both side that aapear  blank or without clearly visible  icons /text that breaks  visual consistency .

Fixes #1849 

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made

- Updated [src/css/custom.css](code-assist-path:c:\Projects\recode\recode-website\src\css\custom.css) to ensure pagination icons (SVGs) are visible across all themes.Updated [src/css/custom.css](code-assist-path:c:\Projects\recode\recode-website\src\css\custom.css) to ensure pagination icons (SVGs) are visible across all themes.
- Enforced stroke: currentColor so icons inherit the button's text color.
- Set explicit width and height (20px) on SVGs to prevent them from collapsing.
-  Increased stroke-width to 2px for better clarity.

<img width="794" height="359" alt="Screenshot 2026-06-05 114104" src="https://github.com/user-attachments/assets/e43f9a41-b4ff-41fb-b814-f754f1e13837" />




## Dependencies

- None 

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers and devices
- [x] My changes do not generate new console warnings or errors .
- [x] I ran `npm run build` and attached screenshot(s) in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.
