### PR TITLE
Fixed visibility in dark theme

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -2620,7 +2620,9 @@ html[data-theme="dark"] .blog-post-page .markdown h4 {
 }
 
 html[data-theme="dark"].blog-post-page .markdown .theme-admonition-info,
-html[data-theme="dark"].blog-post-page .markdown .alert--info {
+html[data-theme="dark"].blog-post-page .markdown .alert--info,
+html[data-theme="dark"].blog-post-page .markdown .theme-admonition-note,
+html[data-theme="dark"].blog-post-page .markdown .alert--secondary {
   --ifm-alert-foreground-color: #ffffff !important;
   --ifm-alert-background-color: #0f172a !important;
   --ifm-alert-background-color-highlight: rgba(148, 163, 184, 0.14) !important;
@@ -2635,6 +2637,8 @@ html[data-theme="dark"].blog-post-page .markdown .alert--info {
 
 html[data-theme="dark"].blog-post-page .markdown .theme-admonition-info [class*="admonitionContent_"],
 html[data-theme="dark"].blog-post-page .markdown .alert--info [class*="admonitionContent_"],
+html[data-theme="dark"].blog-post-page .markdown .theme-admonition-note [class*="admonitionContent_"],
+html[data-theme="dark"].blog-post-page .markdown .alert--secondary [class*="admonitionContent_"],
 html[data-theme="dark"].blog-post-page .markdown .theme-admonition-info [class*="admonitionContent_"] p,
 html[data-theme="dark"].blog-post-page .markdown .theme-admonition-info [class*="admonitionContent_"] li,
 html[data-theme="dark"].blog-post-page .markdown .theme-admonition-info [class*="admonitionContent_"] span,
@@ -2642,13 +2646,27 @@ html[data-theme="dark"].blog-post-page .markdown .theme-admonition-info [class*=
 html[data-theme="dark"].blog-post-page .markdown .theme-admonition-info [class*="admonitionContent_"] em,
 html[data-theme="dark"].blog-post-page .markdown .theme-admonition-info [class*="admonitionContent_"] code,
 html[data-theme="dark"].blog-post-page .markdown .theme-admonition-info [class*="admonitionContent_"] a,
+html[data-theme="dark"].blog-post-page .markdown .theme-admonition-note [class*="admonitionContent_"] p,
+html[data-theme="dark"].blog-post-page .markdown .theme-admonition-note [class*="admonitionContent_"] li,
+html[data-theme="dark"].blog-post-page .markdown .theme-admonition-note [class*="admonitionContent_"] span,
+html[data-theme="dark"].blog-post-page .markdown .theme-admonition-note [class*="admonitionContent_"] strong,
+html[data-theme="dark"].blog-post-page .markdown .theme-admonition-note [class*="admonitionContent_"] em,
+html[data-theme="dark"].blog-post-page .markdown .theme-admonition-note [class*="admonitionContent_"] code,
+html[data-theme="dark"].blog-post-page .markdown .theme-admonition-note [class*="admonitionContent_"] a,
 html[data-theme="dark"].blog-post-page .markdown .alert--info [class*="admonitionContent_"] p,
 html[data-theme="dark"].blog-post-page .markdown .alert--info [class*="admonitionContent_"] li,
 html[data-theme="dark"].blog-post-page .markdown .alert--info [class*="admonitionContent_"] span,
 html[data-theme="dark"].blog-post-page .markdown .alert--info [class*="admonitionContent_"] strong,
 html[data-theme="dark"].blog-post-page .markdown .alert--info [class*="admonitionContent_"] em,
 html[data-theme="dark"].blog-post-page .markdown .alert--info [class*="admonitionContent_"] code,
-html[data-theme="dark"].blog-post-page .markdown .alert--info [class*="admonitionContent_"] a {
+html[data-theme="dark"].blog-post-page .markdown .alert--info [class*="admonitionContent_"] a,
+html[data-theme="dark"].blog-post-page .markdown .alert--secondary [class*="admonitionContent_"] p,
+html[data-theme="dark"].blog-post-page .markdown .alert--secondary [class*="admonitionContent_"] li,
+html[data-theme="dark"].blog-post-page .markdown .alert--secondary [class*="admonitionContent_"] span,
+html[data-theme="dark"].blog-post-page .markdown .alert--secondary [class*="admonitionContent_"] strong,
+html[data-theme="dark"].blog-post-page .markdown .alert--secondary [class*="admonitionContent_"] em,
+html[data-theme="dark"].blog-post-page .markdown .alert--secondary [class*="admonitionContent_"] code,
+html[data-theme="dark"].blog-post-page .markdown .alert--secondary [class*="admonitionContent_"] a {
   color: #ffffff !important;
   -webkit-text-fill-color: #ffffff !important;
 }


### PR DESCRIPTION
## Description

In the  blogs  , the "note" box lacks visibility and readability due to poor contrast making it visually inconsistent in the dark theme  
Fixes #1850 

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made

- modifying the 'custom.css' file to extend dark-theme styling to "note"  admonition containers.
- This ensures that these container types  display with a readable white foreground color and a dark background color  in dark theme, improving visibility and consistency across different admonition types.

<img width="1087" height="502" alt="Screenshot 2026-06-05 124125" src="https://github.com/user-attachments/assets/ed09ed48-8151-4233-9964-80bb639f8314" />


## Dependencies

- None

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers and devices
- [x] My changes do not generate new console warnings or errors .
- [x] I ran `npm run build` and attached screenshot(s) in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.
