### PR TITLE
Fixed overlapping between testimonial and topmate card in Mobile view

### DIFF
--- a/src/components/topmate/TopMateCard.tsx
+++ b/src/components/topmate/TopMateCard.tsx
@@ -48,7 +48,7 @@ const TopMateCard: React.FC<TopMateCardProps> = ({
       initial={{ opacity: 0, y: 30, scale: 0.97 }}
       animate={{ opacity: 1, y: 0, scale: 1 }}
       transition={{ duration: 0.6, ease: [0.25, 0.46, 0.45, 0.94] }}
-      className="group relative flex h-90 w-full flex-col overflow-hidden rounded-2xl transition-all duration-500 hover:scale-[1.008]"
+      className="group relative flex min-h-[360px] w-full flex-col overflow-hidden rounded-2xl transition-all duration-500 hover:scale-[1.008]"
       style={{
         background: isDark ? "#0a0a0a" : "#ffffff",
         border: `1px solid ${borderClr}`,

--- a/src/components/topmate/TopMateSection.tsx
+++ b/src/components/topmate/TopMateSection.tsx
@@ -30,7 +30,7 @@ const TopMateSection = ({ setShowTopmate }) => {
   };
 
   return (
-    <div className="relative flex flex-col w-full h-90">
+    <div className="relative flex flex-col w-full">
       <div className="relative flex w-full flex-col justify-between">
         {/* Section header — unified height & centered alignment */}
         <motion.div


### PR DESCRIPTION
## Description

Elements within the testimonial section and topmate card are overlapping with each other on mobile view .
Closes #1863 
## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made

- h-90 was clipping the card at 360px but the content was taller on mobile, causing overflow into the testimonials section. Replacing with min-h-[360px] lets it grow to fit its content.
- Removed the h-90 from topmatesection.tsx

<img width="309" height="675" alt="Screenshot 2026-06-07 203051" src="https://github.com/user-attachments/assets/60b60eaf-31d1-45c2-9339-44490691af48" />


## Dependencies

- None

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have tested my changes across major browsers and devices
- [x] My changes do not generate new console warnings or errors .
- [x] I ran `npm run build` and attached screenshot(s) in this PR.
- [x] This is already assigned Issue to me, not an unassigned issue.
