### PR TITLE
fix: guard against undefined contentWindow in GiscusComments

### DIFF
--- a/src/components/giscus.tsx
+++ b/src/components/giscus.tsx
@@ -130,7 +130,7 @@ const GiscusComments: React.FC<GiscusCommentsProps> = ({
       "iframe.giscus-frame",
     );
 
-    if (!iframe) {
+    if (!iframe || !iframe.contentWindow) {
       return;
     }
 


### PR DESCRIPTION
## Summary

Fixes #1933

The `GiscusComments` component sends a `postMessage` to the giscus iframe whenever `colorMode` changes. While it already checked if the iframe existed, it didn't verify that the iframe had finished loading.

If `colorMode` changed before `iframe.contentWindow` became available, calling `postMessage` would throw a `TypeError`.

## Fix

Extended the existing guard to ensure both the iframe and its `contentWindow` are available before sending the message.

```js
if (!iframe || !iframe.contentWindow) {
  return;
}
```

## Testing

- Ran the project locally using `npm run start`.
- Reproduced the issue with an isolated test where `contentWindow` was `undefined`, confirming the `Cannot read properties of undefined (reading 'postMessage')` error.
- Verified that toggling the theme on blog posts with Giscus comments no longer produces console errors after the fix.