### PR TITLE
feat: redesign leaderboard with sidebar layout and personal stats

### DIFF
--- a/src/components/dashboard/LeaderBoard/PersonalStats.tsx
+++ b/src/components/dashboard/LeaderBoard/PersonalStats.tsx
@@ -1,0 +1,118 @@
+// src/components/dashboard/LeaderBoard/PersonalStats.tsx
+import React from "react";
+import type { Contributor } from "./leaderboard";
+
+interface PRDetails {
+  mergedAt: string;
+}
+
+const TIERS = [
+  { name: "Scout", min: 0, max: 1 },
+  { name: "Challenger", min: 2, max: 4 },
+  { name: "Knight", min: 5, max: 19 },
+  { name: "Sovereign", min: 20, max: Infinity },
+];
+
+function getTier(prs: number) {
+  return TIERS.find((tier) => prs >= tier.min && prs <= tier.max) ?? TIERS[0];
+}
+
+function getNextTier(prs: number) {
+  const currentIndex = TIERS.findIndex(
+    (tier) => prs >= tier.min && prs <= tier.max,
+  );
+  return TIERS[currentIndex + 1] ?? null;
+}
+
+/**
+ * Counts consecutive weeks (walking backwards from today) with at least one merged PR.
+ */
+function computeStreak(prDetails: PRDetails[] = []): number {
+  if (prDetails.length === 0) return 0;
+
+  const weekMs = 7 * 24 * 60 * 60 * 1000;
+  const now = Date.now();
+
+  const mergedWeeks = new Set(
+    prDetails.map((pr) =>
+      Math.floor((now - new Date(pr.mergedAt).getTime()) / weekMs),
+    ),
+  );
+
+  let streak = 0;
+  let week = 0;
+  while (mergedWeeks.has(week)) {
+    streak++;
+    week++;
+  }
+  return streak;
+}
+
+export default function PersonalStats({
+  contributors,
+  viewerLogin,
+  isDark,
+}: {
+  contributors: Contributor[];
+  viewerLogin: string | null;
+  isDark: boolean;
+}): React.JSX.Element | null {
+  if (!viewerLogin) {
+    return (
+      <div
+        className={`personal-stats-connect ${isDark ? "dark" : "light"}`}
+      >
+        Connect your GitHub account to see your personal rank, streak, and
+        progress.
+      </div>
+    );
+  }
+
+  const viewerIndex = contributors.findIndex(
+    (c) => c.username.toLowerCase() === viewerLogin.toLowerCase(),
+  );
+
+  if (viewerIndex === -1) {
+    return (
+      <div
+        className={`personal-stats-connect ${isDark ? "dark" : "light"}`}
+      >
+        You haven't merged any recode-labeled PRs yet. Contribute to appear on
+        the leaderboard!
+      </div>
+    );
+  }
+
+  const viewer = contributors[viewerIndex];
+  const rank = viewerIndex + 1;
+  const streak = computeStreak(viewer.prDetails as PRDetails[]);
+  const tier = getTier(viewer.prs);
+  const nextTier = getNextTier(viewer.prs);
+  const prsToNext = nextTier ? nextTier.min - viewer.prs : 0;
+
+  return (
+    <div className="personal-stats-strip">
+      <div className="personal-stat-card">
+        <div className="personal-stat-label">Your Rank</div>
+        <div className="personal-stat-value">#{rank}</div>
+      </div>
+      <div className="personal-stat-card">
+        <div className="personal-stat-label">Total Points</div>
+        <div className="personal-stat-value">{viewer.points}</div>
+      </div>
+      <div className="personal-stat-card">
+        <div className="personal-stat-label">Current Streak</div>
+        <div className="personal-stat-value">{streak} wks</div>
+      </div>
+      <div className="personal-stat-card">
+        <div className="personal-stat-label">Tier: {tier.name}</div>
+        <div className="personal-stat-value">{viewer.prs} PRs</div>
+        {nextTier && (
+          <div className="personal-stat-sub">
+            {prsToNext} more PR{prsToNext === 1 ? "" : "s"} to {nextTier.name}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/LeaderBoard/leaderboard.css
+++ b/src/components/dashboard/LeaderBoard/leaderboard.css
@@ -19,6 +19,324 @@
   margin: 0 auto;
 }
 
+/* 2-column layout: main content + sidebar */
+.leaderboard-layout {
+  max-width: 1400px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1fr 280px;
+  gap: 24px;
+  align-items: start;
+}
+
+.leaderboard-layout .leaderboard-content {
+  max-width: none;
+  margin: 0;
+}
+
+.leaderboard-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  position: sticky;
+  top: 24px;
+}
+
+@media (max-width: 1100px) {
+  .leaderboard-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .leaderboard-sidebar {
+    position: static;
+  }
+}
+
+.sidebar-card {
+  border-radius: 14px;
+  padding: 18px;
+  border: 1px solid transparent;
+}
+
+.leaderboard-container.light .sidebar-card {
+  background: #ffffff;
+  border-color: #e5e7eb;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
+.leaderboard-container.dark .sidebar-card {
+  background: #2d3340;
+  border-color: #3a4150;
+}
+
+.sidebar-card-title {
+  font-size: 15px;
+  font-weight: 700;
+  margin-bottom: 14px;
+}
+
+.leaderboard-container.light .sidebar-card-title {
+  color: #1f2937;
+}
+
+.leaderboard-container.dark .sidebar-card-title {
+  color: #f3f4f6;
+}
+
+.sidebar-card-badge {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: #ede9fe;
+  color: #7c3aed;
+  margin-left: 8px;
+}
+
+/* Hive activity card */
+.hive-activity-stats {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.hive-activity-stat {
+  text-align: center;
+  flex: 1;
+}
+
+.hive-activity-value {
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.leaderboard-container.light .hive-activity-value {
+  color: #1f2937;
+}
+
+.leaderboard-container.dark .hive-activity-value {
+  color: #f3f4f6;
+}
+
+.hive-activity-label {
+  font-size: 11px;
+  margin-top: 4px;
+}
+
+.leaderboard-container.light .hive-activity-label {
+  color: #6b7280;
+}
+
+.leaderboard-container.dark .hive-activity-label {
+  color: #9ca3af;
+}
+
+/* How to earn points card */
+.points-callout {
+  font-size: 13px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  margin-bottom: 14px;
+  line-height: 1.5;
+}
+
+.leaderboard-container.light .points-callout {
+  background: #eef2ff;
+  color: #4338ca;
+}
+
+.leaderboard-container.dark .points-callout {
+  background: #312e81;
+  color: #c7d2fe;
+}
+
+.points-level-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 0;
+  font-size: 13px;
+  border-top: 1px solid;
+}
+
+.leaderboard-container.light .points-level-row {
+  border-color: #f0f0f0;
+  color: #374151;
+}
+
+.leaderboard-container.dark .points-level-row {
+  border-color: #3a4150;
+  color: #d1d5db;
+}
+
+.points-level-badge {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 6px;
+  margin-right: 8px;
+}
+
+.points-level-badge.level-1 {
+  background: #dcfce7;
+  color: #16a34a;
+}
+
+.points-level-badge.level-2 {
+  background: #dbeafe;
+  color: #2563eb;
+}
+
+.points-level-badge.level-3 {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+.points-level-value {
+  font-weight: 700;
+  color: #16a34a;
+}
+
+/* Your badges card */
+.sidebar-badges-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.sidebar-badge-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+}
+
+.sidebar-badges-empty {
+  font-size: 13px;
+}
+
+.leaderboard-container.light .sidebar-badges-empty {
+  color: #6b7280;
+}
+
+.leaderboard-container.dark .sidebar-badges-empty {
+  color: #9ca3af;
+}
+
+/* Personal stats strip */
+.personal-stats-strip {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 14px;
+  margin-bottom: 32px;
+}
+
+@media (max-width: 768px) {
+  .personal-stats-strip {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.personal-stat-card {
+  border-radius: 14px;
+  padding: 16px;
+  text-align: center;
+  border: 1px solid transparent;
+}
+
+.leaderboard-container.light .personal-stat-card {
+  background: #ffffff;
+  border-color: #e5e7eb;
+}
+
+.leaderboard-container.dark .personal-stat-card {
+  background: #2d3340;
+  border-color: #3a4150;
+}
+
+.personal-stat-label {
+  font-size: 12px;
+  margin-bottom: 6px;
+}
+
+.leaderboard-container.light .personal-stat-label {
+  color: #6b7280;
+}
+
+.leaderboard-container.dark .personal-stat-label {
+  color: #9ca3af;
+}
+
+.personal-stat-value {
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.leaderboard-container.light .personal-stat-value {
+  color: #1f2937;
+}
+
+.leaderboard-container.dark .personal-stat-value {
+  color: #f3f4f6;
+}
+
+.personal-stat-sub {
+  font-size: 11px;
+  margin-top: 4px;
+  color: #16a34a;
+}
+
+.personal-stats-connect {
+  padding: 16px;
+  border-radius: 12px;
+  text-align: center;
+  font-size: 14px;
+  margin-bottom: 24px;
+}
+
+.leaderboard-container.light .personal-stats-connect {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.leaderboard-container.dark .personal-stats-connect {
+  background: #78350f;
+  color: #fde68a;
+}
+
+/* YOU row highlight */
+.contributor-row.you-row {
+  border: 2px solid #6366f1 !important;
+  border-radius: 10px;
+}
+
+.you-chip {
+  display: inline-block;
+  margin-left: 8px;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: #6366f1;
+  color: #fff;
+  vertical-align: middle;
+}
+
+/* Rank medallion colors */
+.rank-badge.top-1 {
+  background: linear-gradient(135deg, #fbbf24, #f59e0b);
+  color: #fff;
+}
+
+.rank-badge.top-2 {
+  background: linear-gradient(135deg, #d1d5db, #9ca3af);
+  color: #fff;
+}
+
+.rank-badge.top-3 {
+  background: linear-gradient(135deg, #d97706, #92400e);
+  color: #fff;
+}
+
 /* Header */
 .header {
   text-align: center;

--- a/src/components/dashboard/LeaderBoard/leaderboard.tsx
+++ b/src/components/dashboard/LeaderBoard/leaderboard.tsx
@@ -1,12 +1,14 @@
 // src/components/dashboard/LeaderBoard/leaderboard.tsx
 import React, { JSX, useState, useCallback } from "react";
 import { motion } from "framer-motion";
-import { FaStar, FaCode, FaUsers, FaGithub, FaSearch } from "react-icons/fa";
+import { FaGithub, FaSearch } from "react-icons/fa";
 import { ChevronRight, ChevronLeft } from "lucide-react";
+import { useUser } from "@clerk/react";
 import { useSafeColorMode } from "@site/src/utils/useSafeColorMode";
 import { useCommunityStatsContext } from "@site/src/lib/statsProvider";
 import PRListModal from "./PRListModal";
 import BadgeModal from "./BadgeModal";
+import PersonalStats from "./PersonalStats";
 import { mockContributors } from "./mockData";
 import "./leaderboard.css";
 
@@ -282,6 +284,17 @@ export default function LeaderBoard(): JSX.Element {
   } = useCommunityStatsContext();
 
   const { isDark } = useSafeColorMode();
+  // useUser() throws if no ClerkProvider is mounted (e.g. Clerk not configured
+  // locally); guard so the leaderboard still renders without personalization.
+  let clerkUser: ReturnType<typeof useUser>["user"] | undefined;
+  try {
+    clerkUser = useUser().user;
+  } catch {
+    clerkUser = undefined;
+  }
+  const viewerLogin =
+    clerkUser?.externalAccounts?.find((a) => a.provider === "github")
+      ?.username ?? null;
 
   const [searchQuery, setSearchQuery] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
@@ -463,8 +476,23 @@ export default function LeaderBoard(): JSX.Element {
     }
   };
 
+  // Viewer's raw contributor entry (pre-exclusion) for sidebar badges/personal stats
+  const viewerContributorIndex = viewerLogin
+    ? displayContributors.findIndex(
+        (c) => c.username.toLowerCase() === viewerLogin.toLowerCase(),
+      )
+    : -1;
+  const viewerBadges =
+    viewerContributorIndex !== -1
+      ? getContributorBadges(
+          displayContributors[viewerContributorIndex],
+          viewerContributorIndex + 1,
+        )
+      : [];
+
   return (
     <div className={`leaderboard-container ${isDark ? "dark" : "light"}`}>
+      <div className="leaderboard-layout">
       <div className="leaderboard-content">
         {/* Header */}
         <motion.div
@@ -479,6 +507,13 @@ export default function LeaderBoard(): JSX.Element {
             organization
           </p>
         </motion.div>
+
+        {/* Personal stats strip */}
+        <PersonalStats
+          contributors={displayContributors}
+          viewerLogin={viewerLogin}
+          isDark={isDark}
+        />
 
         {/* Top 3 Performers Section */}
         {!loading && filteredContributors.length > 2 && (
@@ -626,57 +661,6 @@ export default function LeaderBoard(): JSX.Element {
           </div>
         )}
 
-        {/* Stats */}
-        {stats && (
-          <div className="stats-grid">
-            <div className={`stat-card ${isDark ? "dark" : "light"}`}>
-              <div className="stat-content">
-                <div className={`stat-icon users`}>
-                  <FaUsers />
-                </div>
-                <div>
-                  <div className={`stat-value ${isDark ? "dark" : "light"}`}>
-                    {stats.totalContributors}
-                  </div>
-                  <div className={`stat-label ${isDark ? "dark" : "light"}`}>
-                    Total Contributors
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div className={`stat-card ${isDark ? "dark" : "light"}`}>
-              <div className="stat-content">
-                <div className={`stat-icon prs`}>
-                  <FaCode />
-                </div>
-                <div>
-                  <div className={`stat-value ${isDark ? "dark" : "light"}`}>
-                    {stats.flooredTotalPRs}
-                  </div>
-                  <div className={`stat-label ${isDark ? "dark" : "light"}`}>
-                    Merged PRs
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div className={`stat-card ${isDark ? "dark" : "light"}`}>
-              <div className="stat-content">
-                <div className={`stat-icon points`}>
-                  <FaStar />
-                </div>
-                <div>
-                  <div className={`stat-value ${isDark ? "dark" : "light"}`}>
-                    {stats.flooredTotalPoints}
-                  </div>
-                  <div className={`stat-label ${isDark ? "dark" : "light"}`}>
-                    Total Points
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
-
         {/* Search */}
         <div className="search-container">
           <div className="search-wrapper">
@@ -757,13 +741,18 @@ export default function LeaderBoard(): JSX.Element {
               <div className="contributor-cell points-cell">Points</div>
               <div className="contributor-cell badges-cell">Badges</div>
             </div>
-            {currentItems.map((contributor, index) => (
+            {currentItems.map((contributor, index) => {
+              const isViewer =
+                !!viewerLogin &&
+                contributor.username.toLowerCase() ===
+                  viewerLogin.toLowerCase();
+              return (
               <motion.div
                 key={contributor.username}
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.3, delay: index * 0.05 }}
-                className={`contributor-row ${isDark ? (index % 2 === 0 ? "even" : "odd") : index % 2 === 0 ? "even" : "odd"}`}
+                className={`contributor-row ${isDark ? (index % 2 === 0 ? "even" : "odd") : index % 2 === 0 ? "even" : "odd"} ${isViewer ? "you-row" : ""}`}
               >
                 {/*
                   This avoids indexOf() issues and is O(1).
@@ -794,6 +783,7 @@ export default function LeaderBoard(): JSX.Element {
                   >
                     {contributor.username}
                   </a>
+                  {isViewer && <span className="you-chip">YOU</span>}
                 </div>
                 <div className="contributor-cell prs-cell">
                   <Badge
@@ -821,7 +811,8 @@ export default function LeaderBoard(): JSX.Element {
                   />
                 </div>
               </motion.div>
-            ))}
+              );
+            })}
 
             {/* Pagination */}
             {totalPages > 1 && (
@@ -865,6 +856,96 @@ export default function LeaderBoard(): JSX.Element {
             </div>
           </div>
         )}
+      </div>
+
+      {/* Sidebar */}
+      <div className="leaderboard-sidebar">
+        {stats && (
+          <div className="sidebar-card">
+            <div className="sidebar-card-title">
+              Hive activity
+              <span className="sidebar-card-badge">
+                {getTimeFilterLabel(currentTimeFilter).replace(/^\S+\s/, "")}
+              </span>
+            </div>
+            <div className="hive-activity-stats">
+              <div className="hive-activity-stat">
+                <div className="hive-activity-value">
+                  {stats.totalContributors}
+                </div>
+                <div className="hive-activity-label">Contributors</div>
+              </div>
+              <div className="hive-activity-stat">
+                <div className="hive-activity-value">
+                  {stats.flooredTotalPRs}
+                </div>
+                <div className="hive-activity-label">Merged PRs</div>
+              </div>
+              <div className="hive-activity-stat">
+                <div className="hive-activity-value">
+                  {stats.flooredTotalPoints}
+                </div>
+                <div className="hive-activity-label">Total Points</div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div className="sidebar-card">
+          <div className="sidebar-card-title">How to earn points</div>
+          <div className="points-callout">
+            Points count only when your merged PR carries the{" "}
+            <strong>recode</strong> label and a level label.
+          </div>
+          <div className="points-level-row">
+            <span>
+              <span className="points-level-badge level-1">level 1</span>
+              Good first issue
+            </span>
+            <span className="points-level-value">+10</span>
+          </div>
+          <div className="points-level-row">
+            <span>
+              <span className="points-level-badge level-2">level 2</span>
+              Feature / fix
+            </span>
+            <span className="points-level-value">+30</span>
+          </div>
+          <div className="points-level-row">
+            <span>
+              <span className="points-level-badge level-3">level 3</span>
+              Major contribution
+            </span>
+            <span className="points-level-value">+50</span>
+          </div>
+        </div>
+
+        <div className="sidebar-card">
+          <div className="sidebar-card-title">Your badges</div>
+          {viewerBadges.length > 0 ? (
+            <div className="sidebar-badges-grid">
+              {viewerBadges.map((badge, i) => (
+                <img
+                  key={i}
+                  src={badge}
+                  alt={`Badge ${i + 1}`}
+                  className="sidebar-badge-icon"
+                  title={
+                    BADGE_CONFIG.find((b) => b.image === badge)?.name ||
+                    "Achievement Badge"
+                  }
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="sidebar-badges-empty">
+              {viewerLogin
+                ? "No badges yet — merge a recode-labeled PR to earn one."
+                : "Connect your GitHub account to see your badges."}
+            </div>
+          )}
+        </div>
+      </div>
       </div>
 
       {/* PR List Modal */}

--- a/src/lib/statsProvider.tsx
+++ b/src/lib/statsProvider.tsx
@@ -94,7 +94,6 @@ interface CommunityStatsProviderProps {
 }
 
 const GITHUB_ORG = "recodehive";
-const POINTS_PER_PR = 10;
 const MAX_CONCURRENT_REQUESTS = 15;
 const CACHE_DURATION = 20 * 60 * 1000; // 20 minutes cache
 const MAX_PAGES_PER_REPO = 10;


### PR DESCRIPTION
Adds a 2-column layout (Hive activity / how-to-earn-points / your badges sidebar), a personal stats strip showing the viewer's rank, points, streak, and next-tier progress, and a highlighted "YOU" row in the contributors table. Viewer identity is resolved via Clerk's useUser() -> GitHub externalAccount, with a safe fallback when no ClerkProvider is mounted. Also removes the unused POINTS_PER_PR constant in statsProvider.tsx.

## Description

<!-- 
Provide a brief summary of the changes made to the website and the motivation behind them. Include any relevant issues or tickets.
This helps fast tracking your PR and merge it, Check the respective box below.
-->
Fixes # (issue)

## Type of Change

- [ ] New feature (e.g., new page, component, or functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] UI/UX improvement (design, layout, or styling updates)
- [ ] Performance optimization (e.g., code splitting, caching)
- [ ] Documentation update (README, contribution guidelines, etc.)
- [ ] Other (please specify):

## Changes Made

<!--
Describe the key changes (e.g., new sections, updated components, responsive fixes).
-->

## Dependencies

- List any new dependencies or tools required for this change.
- Mention any version updates or configurations that need to be considered.

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have tested my changes across major browsers and devices
- [ ] My changes do not generate new console warnings or errors .
- [ ] I ran `npm run build` and attached screenshot(s) in this PR.
- [ ] This is already assigned Issue to me, not an unassigned issue.
