### PR TITLE
feat: new collapsible dashboard sidebar with profile menu

### DIFF
--- a/src/components/dashboard/Sidebar/DashboardSidebar.css
+++ b/src/components/dashboard/Sidebar/DashboardSidebar.css
@@ -1,0 +1,237 @@
+/* src/components/dashboard/Sidebar/DashboardSidebar.css */
+
+.dashboard-rail {
+  width: 232px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  position: sticky;
+  top: 0;
+  border-right: 1px solid var(--ifm-color-emphasis-200);
+  background: var(--ifm-background-color);
+  transition: width 0.2s ease;
+  overflow: hidden;
+}
+
+.dashboard-rail.collapsed {
+  width: 64px;
+}
+
+/* Profile header */
+.dashboard-rail-profile {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 12px;
+  border-bottom: 1px solid var(--ifm-color-emphasis-200);
+}
+
+.dashboard-rail-profile-trigger {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 8px;
+  color: var(--ifm-color-content);
+}
+
+.dashboard-rail-profile-trigger:hover {
+  background: var(--ifm-color-emphasis-100);
+}
+
+.dashboard-rail-avatar {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  object-fit: cover;
+}
+
+.dashboard-rail-avatar-fallback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--dashboard-accent, #8b5cf6);
+  color: #ffffff;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.dashboard-rail-name {
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+}
+
+.dashboard-rail-chevron {
+  flex-shrink: 0;
+  opacity: 0.6;
+}
+
+.dashboard-rail-collapse-btn {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 6px;
+  border-radius: 6px;
+  color: var(--ifm-color-content-secondary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dashboard-rail-collapse-btn:hover {
+  background: var(--ifm-color-emphasis-100);
+  color: var(--ifm-color-content);
+}
+
+.dashboard-rail.collapsed .dashboard-rail-profile {
+  flex-direction: column;
+  gap: 6px;
+}
+
+.dashboard-rail-profile-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 12px;
+  min-width: 160px;
+  background: var(--ifm-background-color);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  padding: 6px;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+}
+
+.dashboard-rail-profile-menu button {
+  background: none;
+  border: none;
+  text-align: left;
+  padding: 8px 10px;
+  border-radius: 6px;
+  font-size: 13px;
+  cursor: pointer;
+  color: var(--ifm-color-content);
+}
+
+.dashboard-rail-profile-menu button:hover {
+  background: var(--ifm-color-emphasis-100);
+}
+
+.dashboard-rail-profile-menu-danger {
+  color: #dc2626 !important;
+}
+
+/* Nav */
+.dashboard-rail-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 12px 8px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.dashboard-rail-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  border: none;
+  background: none;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ifm-color-content);
+  text-decoration: none;
+  width: 100%;
+}
+
+.dashboard-rail-item:hover {
+  background: color-mix(in srgb, var(--ifm-color-emphasis-100) 50%, transparent);
+  color: var(--ifm-color-content);
+}
+
+[data-theme="light"] .dashboard-rail-item.active {
+  background: #f1f2f5;
+  color: #111827;
+  font-weight: 600;
+}
+
+[data-theme="dark"] .dashboard-rail-item.active {
+  background: #262a33;
+  color: #f3f4f6;
+  font-weight: 600;
+}
+
+.dashboard-rail-item-icon {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.dashboard-rail-item-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dashboard-rail.collapsed .dashboard-rail-item {
+  justify-content: center;
+}
+
+.dashboard-rail-divider {
+  height: 1px;
+  background: var(--ifm-color-emphasis-200);
+  margin: 8px 4px;
+}
+
+/* Notifications footer */
+.dashboard-rail-notifications {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 18px;
+  margin-top: auto;
+  border-top: 1px solid var(--ifm-color-emphasis-200);
+  background: none;
+  border-left: none;
+  border-right: none;
+  border-bottom: none;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ifm-color-content-secondary);
+}
+
+.dashboard-rail-notifications:hover {
+  color: var(--ifm-color-content);
+}
+
+.dashboard-rail.collapsed .dashboard-rail-notifications {
+  justify-content: center;
+  padding: 14px 0;
+}
+
+/* Collapse behavior only applies at desktop widths */
+@media (max-width: 1023px) {
+  .dashboard-rail {
+    display: none;
+  }
+}

--- a/src/components/dashboard/Sidebar/DashboardSidebar.tsx
+++ b/src/components/dashboard/Sidebar/DashboardSidebar.tsx
@@ -1,0 +1,203 @@
+// src/components/dashboard/Sidebar/DashboardSidebar.tsx
+import React, { useEffect, useRef, useState } from "react";
+import Link from "@docusaurus/Link";
+import { useUser, useClerk } from "@clerk/react";
+import {
+  LayoutGrid,
+  MessageCircle,
+  Trophy,
+  Gift,
+  BookOpen,
+  Smile,
+  Bell,
+  ChevronDown,
+  PanelLeft,
+} from "lucide-react";
+import "./DashboardSidebar.css";
+
+export type DashboardTab = "home" | "discuss" | "giveaway" | "contributors";
+
+interface DashboardSidebarProps {
+  activeTab: DashboardTab;
+  onTabChange: (tab: DashboardTab) => void;
+}
+
+const COLLAPSE_STORAGE_KEY = "recodehive:dashboard-sidebar-collapsed";
+
+const TAB_ITEMS: Array<{
+  tab: DashboardTab;
+  label: string;
+  icon: React.ReactNode;
+}> = [
+  { tab: "home", label: "Home", icon: <LayoutGrid size={16} /> },
+  { tab: "discuss", label: "Discussions", icon: <MessageCircle size={16} /> },
+  { tab: "contributors", label: "LeaderBoard", icon: <Trophy size={16} /> },
+  { tab: "giveaway", label: "Giveaways", icon: <Gift size={16} /> },
+];
+
+const LINK_ITEMS: Array<{ href: string; label: string; icon: React.ReactNode }> = [
+  { href: "/blogs", label: "Blogs", icon: <BookOpen size={16} /> },
+  { href: "/community", label: "Community", icon: <Smile size={16} /> },
+];
+
+export default function DashboardSidebar({
+  activeTab,
+  onTabChange,
+}: DashboardSidebarProps): React.JSX.Element {
+  const { user } = useUser();
+  const { signOut, openUserProfile } = useClerk();
+
+  const [collapsed, setCollapsed] = useState(false);
+  const [isProfileMenuOpen, setIsProfileMenuOpen] = useState(false);
+  const profileMenuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem(COLLAPSE_STORAGE_KEY);
+    if (stored === "true") setCollapsed(true);
+  }, []);
+
+  const toggleCollapsed = () => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      window.localStorage.setItem(COLLAPSE_STORAGE_KEY, String(next));
+      return next;
+    });
+  };
+
+  useEffect(() => {
+    if (!isProfileMenuOpen) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        profileMenuRef.current &&
+        !profileMenuRef.current.contains(event.target as Node)
+      ) {
+        setIsProfileMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isProfileMenuOpen]);
+
+  const displayName = user?.fullName ?? user?.username ?? "Account";
+
+  return (
+    <div
+      className={`dashboard-rail ${collapsed ? "collapsed" : ""}`}
+      data-testid="dashboard-sidebar"
+    >
+      <div className="dashboard-rail-profile" ref={profileMenuRef}>
+        <button
+          type="button"
+          className="dashboard-rail-profile-trigger"
+          onClick={() => setIsProfileMenuOpen((open) => !open)}
+          aria-haspopup="menu"
+          aria-expanded={isProfileMenuOpen}
+        >
+          {user?.imageUrl ? (
+            <img
+              src={user.imageUrl}
+              alt={displayName}
+              className="dashboard-rail-avatar"
+            />
+          ) : (
+            <div className="dashboard-rail-avatar dashboard-rail-avatar-fallback">
+              {displayName.charAt(0).toUpperCase()}
+            </div>
+          )}
+          {!collapsed && (
+            <>
+              <span className="dashboard-rail-name" title={displayName}>
+                {displayName}
+              </span>
+              <ChevronDown size={14} className="dashboard-rail-chevron" />
+            </>
+          )}
+        </button>
+
+        {isProfileMenuOpen && (
+          <div className="dashboard-rail-profile-menu" role="menu">
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setIsProfileMenuOpen(false);
+                openUserProfile();
+              }}
+            >
+              Manage account
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              className="dashboard-rail-profile-menu-danger"
+              onClick={() => {
+                setIsProfileMenuOpen(false);
+                signOut();
+              }}
+            >
+              Sign out
+            </button>
+          </div>
+        )}
+
+        <button
+          type="button"
+          className="dashboard-rail-collapse-btn"
+          onClick={toggleCollapsed}
+          aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+          title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+        >
+          <PanelLeft
+            size={16}
+            style={{ transform: collapsed ? "scaleX(-1)" : undefined }}
+          />
+        </button>
+      </div>
+
+      <nav className="dashboard-rail-nav">
+        {TAB_ITEMS.map((item) => (
+          <button
+            key={item.tab}
+            type="button"
+            className={`dashboard-rail-item ${activeTab === item.tab ? "active" : ""}`}
+            onClick={() => onTabChange(item.tab)}
+            title={collapsed ? item.label : undefined}
+          >
+            <span className="dashboard-rail-item-icon">{item.icon}</span>
+            {!collapsed && (
+              <span className="dashboard-rail-item-label">{item.label}</span>
+            )}
+          </button>
+        ))}
+
+        <div className="dashboard-rail-divider" />
+
+        {LINK_ITEMS.map((item) => (
+          <Link
+            key={item.href}
+            to={item.href}
+            className="dashboard-rail-item"
+            title={collapsed ? item.label : undefined}
+          >
+            <span className="dashboard-rail-item-icon">{item.icon}</span>
+            {!collapsed && (
+              <span className="dashboard-rail-item-label">{item.label}</span>
+            )}
+          </Link>
+        ))}
+      </nav>
+
+      <button
+        type="button"
+        className="dashboard-rail-notifications"
+        title={collapsed ? "Notifications" : undefined}
+        onClick={() => {
+          /* stub — notifications not implemented yet */
+        }}
+      >
+        <Bell size={16} />
+        {!collapsed && <span>Notifications</span>}
+      </button>
+    </div>
+  );
+}

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -27,11 +27,10 @@ import {
   Home,
   Users,
   Gift,
-  ArrowLeft,
   GitFork,
   RefreshCw,
 } from "lucide-react";
-import NavbarIcon from "@site/src/components/navbar/NavbarIcon";
+import DashboardSidebar from "@site/src/components/dashboard/Sidebar/DashboardSidebar";
 import "@site/src/components/discussions/discussions.css";
 import "./dashboard.css";
 import LeaderBoard from "@site/src/components/dashboard/LeaderBoard/leaderboard";
@@ -459,44 +458,7 @@ const DashboardContent: React.FC = () => {
         </div>
       </div>
 
-      <div className="dashboard-sidebar">
-        <div className="sidebar-header">
-          <button
-            className="back-button"
-            onClick={() => history.goBack()}
-            aria-label="Go back"
-          >
-            <ArrowLeft />
-          </button>
-        </div>
-        <div className="sidebar-nav">
-          <NavbarIcon
-            icon={<Home size={20} />}
-            text="Home"
-            active={activeTab === "home"}
-            onClick={() => handleTabChange("home")}
-          />
-          <NavbarIcon
-            icon={<MessageCircle size={20} />}
-            text="Discussions"
-            active={activeTab === "discuss"}
-            onClick={() => handleTabChange("discuss")}
-          />
-          <NavbarIcon
-            icon={<Users size={20} />}
-            text="LeaderBoard
-"
-            active={activeTab === "contributors"}
-            onClick={() => handleTabChange("contributors")}
-          />
-          <NavbarIcon
-            icon={<Gift size={20} />}
-            text="Giveaways"
-            active={activeTab === "giveaway"}
-            onClick={() => handleTabChange("giveaway")}
-          />
-        </div>
-      </div>
+      <DashboardSidebar activeTab={activeTab} onTabChange={handleTabChange} />
 
       <div className="dashboard-main-content">
         <Head>


### PR DESCRIPTION
## Summary
- Extracts the dashboard's left nav into a standalone `DashboardSidebar` component (232px, collapsible to 64px, state persisted in localStorage)
- Adds a Clerk-powered profile header (avatar, name, dropdown with Manage account / Sign out)
- Replaces text-only tabs with icon+label rows (Home, Discussions, LeaderBoard, Giveaways) plus Blogs/Community links
- Matches site theme tokens for active/hover states in light and dark mode

## Test plan
- [ ] Verify sidebar renders correctly in light and dark mode
- [ ] Verify collapse/expand toggle persists across reloads
- [ ] Verify profile dropdown (Manage account, Sign out) works
- [ ] Verify all nav tabs and links (Blogs, Community) navigate correctly
- [ ] Verify mobile view still uses the existing off-canvas menu (sidebar hidden < 1024px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)