### PR TITLE
fix: resolve overlapping hero text animation on Get Started page

### DIFF
--- a/src/pages/get-started/index.tsx
+++ b/src/pages/get-started/index.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode, useState, useEffect, useRef } from "react";
 import Layout from "@theme/Layout";
 import Link from "@docusaurus/Link";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
-import { motion, useAnimation, useInView } from "framer-motion";
+import { motion, useAnimation, useInView, AnimatePresence } from "framer-motion";
 import Head from "@docusaurus/Head";
 import { useColorMode } from "@docusaurus/theme-common";
 import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
@@ -156,10 +156,17 @@ function GetStartedHeader() {
             <div className={styles.staticText}>
               <span className={styles.staticText}>Start&nbsp;</span>
               <span className={styles.dynamicText}>
-                <span className={styles.typingWord}>Code</span>
-                <span className={styles.typingWord}>Build</span>
-                <span className={styles.typingWord}>Deploy</span>
-                <span className={styles.typingWord}>Learn</span>
+                 <AnimatePresence mode="wait">
+                <motion.span
+                   key={texts[textIndex]}
+                   className={styles.typingWord}
+                   initial={{ opacity: 0, y: 8 }}
+                   animate={{ opacity: 1, y: 0 }}
+                   exit={{ opacity: 0, y: -8 }}
+                   transition={{ duration: 0.35, ease: "easeInOut" }}>
+                  {texts[textIndex]}
+                </motion.span>
+               </AnimatePresence>
               </span>
               <span className={styles.staticText}>&nbsp;Today</span>
             </div>

--- a/src/pages/get-started/styles.module.css
+++ b/src/pages/get-started/styles.module.css
@@ -1059,56 +1059,20 @@
   flex: 0 1 auto;
 }
 
+/* Only one word is ever rendered at a time (see AnimatePresence in
+    index.tsx), so no absolute stacking / keyframe timing is needed here.
+    This avoids the overlapping-text bug from the previous pure-CSS
+    multi-word animation (issue #2073). */
 .typingWord {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  opacity: 0;
-  animation: typing 12s ease-in-out infinite;
+  display: inline-block;
   white-space: nowrap;
-  background: linear-gradient(90deg, #22d3ee, #60a5fa);
-  background-clip: text;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  font-weight: 800;
-  letter-spacing: 0.5px;
-}
-
-.typingWord:nth-child(1) {
-  animation-delay: 0s;
-}
-.typingWord:nth-child(2) {
-  animation-delay: 3s;
-}
-.typingWord:nth-child(3) {
-  animation-delay: 6s;
-}
-.typingWord:nth-child(4) {
-  animation-delay: 9s;
-}
-
-@keyframes typing {
-  0% {
-    opacity: 0;
-    transform: translate(-50%, 100%);
-  }
-  5% {
-    opacity: 1;
-    transform: translate(-50%, -50%);
-  }
-  20% {
-    opacity: 1;
-    transform: translate(-50%, -50%);
-  }
-  25% {
-    opacity: 0;
-    transform: translate(-50%, -200%);
-  }
-  100% {
-    opacity: 0;
-  }
-}
+   background: linear-gradient(90deg, #22d3ee, #60a5fa);
+   background-clip: text;
+   -webkit-background-clip: text;
+   -webkit-text-fill-color: transparent;
+   font-weight: 800;
+   letter-spacing: 0.5px;
+ }
 
 .dynamicText::after {
   content: "|";


### PR DESCRIPTION
Fixes #2073

## Problem
The "START [Code/Build/Deploy/Learn] TODAY" pill on the Get Started page 
displayed overlapping text instead of cycling through the words cleanly.

<img width="1891" height="693" alt="proff" src="https://github.com/user-attachments/assets/c665c553-3e94-43bb-b29f-6e0e0b3ceeb6" />



## Root Cause
All four words were rendered simultaneously as absolutely-positioned 
sibling spans inside `.dynamicText`, with visibility controlled purely 
by a CSS `@keyframes` animation staggered via `:nth-child` delays. A 
`textIndex` React state already existed (via `useState`/`setInterval`) 
but was never actually wired to the render output — it was dead code. 
Relying solely on independently-timed CSS keyframes for four stacked 
absolute elements is fragile across browsers/re-renders, which caused 
the words to render visible at the same time.

## Fix
- Render only the current word (`texts[textIndex]`), driven by the 
  existing `textIndex` state, wrapped in Framer Motion's 
  `AnimatePresence` for a smooth crossfade between words.
- Removed the now-unnecessary `position: absolute`, `@keyframes typing`, 
  and `:nth-child` delay rules from `.typingWord` in 
  `styles.module.css`, since only one word is ever mounted at a time.

Since only one word exists in the DOM at any moment, overlapping text 
is now structurally impossible.

## Files Changed
- `src/pages/get-started/index.tsx`
- `src/pages/get-started/styles.module.css`

## Testing
- Verified locally with `npm run start` on the Get Started page.
- Confirmed words cycle one at a time with no overlap.
- Checked responsive behavior at tablet/mobile breakpoints (existing 
  media query overrides for `.typingWord` still apply).