### PR TITLE
fix: redirect Read Blog footer button to /blogs (#2074)

### DIFF
--- a/src/theme/Footer/Layout/index.tsx
+++ b/src/theme/Footer/Layout/index.tsx
@@ -132,7 +132,7 @@ export default function FooterLayout(): ReactNode {
               <span>code second.</span>
             </p>
             <div className="rh-footer__cta">
-              <Link to="/blog" className="rh-btn rh-btn--white">
+              <Link to="/blogs" className="rh-btn rh-btn--white">
                 <svg
                   className="rh-btn__icon"
                   width="16"


### PR DESCRIPTION
#2074
<img width="823" height="766" alt="image" src="https://github.com/user-attachments/assets/9a77a65c-979f-49e7-b2e7-46c922186dd3" />
