### PR TITLE
fix: profile dropdown clipped behind collapsed sidebar (#2072)

### DIFF
--- a/src/components/dashboard/Sidebar/DashboardSidebar.css
+++ b/src/components/dashboard/Sidebar/DashboardSidebar.css
@@ -11,7 +11,7 @@
   border-right: 1px solid var(--ifm-color-emphasis-200);
   background: var(--ifm-background-color);
   transition: width 0.2s ease;
-  overflow: hidden;
+  
 }
 
 .dashboard-rail.collapsed {
@@ -113,7 +113,7 @@
   border-radius: 10px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
   padding: 6px;
-  z-index: 20;
+  z-index: 1000;
   display: flex;
   flex-direction: column;
 }

--- a/src/theme/Footer/Layout/index.tsx
+++ b/src/theme/Footer/Layout/index.tsx
@@ -132,7 +132,7 @@ export default function FooterLayout(): ReactNode {
               <span>code second.</span>
             </p>
             <div className="rh-footer__cta">
-              <Link to="/blog" className="rh-btn rh-btn--white">
+              <Link to="/blogs" className="rh-btn rh-btn--white">
                 <svg
                   className="rh-btn__icon"
                   width="16"


### PR DESCRIPTION
## What was changed
Removed `overflow: hidden` from `.dashboard-rail` in DashboardSidebar.css, and raised
`.dashboard-rail-profile-menu`'s z-index from 20 to 1000.

## Why
The sidebar container's `overflow: hidden` clipped the absolutely-positioned profile
dropdown menu whenever it extended past the container's edge — most visibly when the
sidebar is collapsed to 64px but the dropdown is 160px wide. z-index alone can't fix
clipping caused by an ancestor's overflow, since clipping happens before stacking order
is evaluated.

Fixes #2072